### PR TITLE
Fix dynamic property deprecation warnings

### DIFF
--- a/src/analytics.php
+++ b/src/analytics.php
@@ -1,10 +1,13 @@
 <?php
 class AdvancedAnalytics {
-    
-    public function __construct($pdo)
-        {
-            $this->pdo = $pdo;
-        }
+
+    /** @var PDO */
+    private $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
     
     public function startSession() {
         if (!isset($_SESSION['session_start_time'])) {

--- a/src/database.class.php
+++ b/src/database.class.php
@@ -27,10 +27,13 @@ $indexed = $db->runQuery("SELECT id, name FROM users")->fetchAll(PDO::FETCH_KEY_
 */
 class database {
 
-	public function __construct($pdo)
-        {
-            $this->pdo = $pdo;
-        }
+    /** @var PDO */
+    private $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
     
 	public function runQuery($sql, $parameters = []) {
     

--- a/src/site.class.php
+++ b/src/site.class.php
@@ -1,10 +1,13 @@
 <?php
 class site {
 
-	public function __construct($pdo)
-        {
-            $this->pdo = $pdo;
-        }
+    /** @var PDO */
+    private $pdo;
+
+    public function __construct(PDO $pdo)
+    {
+        $this->pdo = $pdo;
+    }
     
     /* START GETTNG DATA FOR WEBSITES */
 	function getConfig ($loc_website) {


### PR DESCRIPTION
## Summary
- define PDO property in `database`, `site`, and `AdvancedAnalytics` classes

## Testing
- `php -l src/database.class.php`
- `php -l src/site.class.php`
- `php -l src/analytics.php`


------
https://chatgpt.com/codex/tasks/task_e_6849fc5911d0832a8568d825deaa469a