### PR TITLE
Fix dynamic properties

### DIFF
--- a/admin/modules/admin_users/src/admin_users.class.php
+++ b/admin/modules/admin_users/src/admin_users.class.php
@@ -1,8 +1,11 @@
 <?php
 class adminUsers {
+
+        /** @var PDO */
+        private PDO $pdo;
 	
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllAdminUsers() {

--- a/admin/modules/auctions/src/auction.class.php
+++ b/admin/modules/auctions/src/auction.class.php
@@ -12,8 +12,11 @@ reaction
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        /** @var PDO */
+        private PDO $pdo;
+
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 function getAllAuctions($orderBy = 'enddate', $orderDirection = 'ASC') {

--- a/admin/modules/banners/src/banners.class.php
+++ b/admin/modules/banners/src/banners.class.php
@@ -11,8 +11,11 @@ enddate
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        /** @var PDO */
+        private PDO $pdo;
+
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllBanners() {

--- a/admin/modules/carousel/src/carousel.class.php
+++ b/admin/modules/carousel/src/carousel.class.php
@@ -11,8 +11,11 @@ image
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        /** @var PDO */
+        private PDO $pdo;
+
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllImages() {

--- a/admin/modules/content/src/content.class.php
+++ b/admin/modules/content/src/content.class.php
@@ -23,10 +23,12 @@ status
 	public $seo_url = 0;
 	public $keywords = 0;
 	public $sortnum = 0;
-	public $status = 0;
-	*/
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        public $status = 0;
+        */
+        /** @var PDO */
+        private PDO $pdo;
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getKeywords( $groupid, $keyword ) {

--- a/admin/modules/gallery/src/gallery.class.php
+++ b/admin/modules/gallery/src/gallery.class.php
@@ -11,8 +11,11 @@ image
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        /** @var PDO */
+        private PDO $pdo;
+
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllImages() {

--- a/admin/modules/keywords/src/keywords.class.php
+++ b/admin/modules/keywords/src/keywords.class.php
@@ -1,8 +1,11 @@
 <?php
 class keywords {
+
+        /** @var PDO */
+        private PDO $pdo;
 	
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getKeywordsList($groupid ) {

--- a/admin/modules/reviews/src/review.class.php
+++ b/admin/modules/reviews/src/review.class.php
@@ -13,8 +13,11 @@ reviewdate
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        /** @var PDO */
+        private PDO $pdo;
+
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllReviews() {

--- a/admin/modules/siteconfig/src/site_config.php
+++ b/admin/modules/siteconfig/src/site_config.php
@@ -1,6 +1,9 @@
 <?php
 class siteConfig {
 
+  /** @var PDO */
+  private PDO $pdo;
+
   function __construct( $pdo ) {
     $this->pdo = $pdo;
   }

--- a/admin/modules/theme/src/theme.class.php
+++ b/admin/modules/theme/src/theme.class.php
@@ -1,5 +1,8 @@
 <?php
 class themeConfig {
+
+  /** @var PDO */
+  private PDO $pdo;
     
   function __construct( $pdo ) {
     $this->pdo = $pdo;

--- a/admin/src/analytics.class.php
+++ b/admin/src/analytics.class.php
@@ -1,5 +1,8 @@
 <?php
 class Analytics {
+
+    /** @var PDO */
+    private PDO $pdo;
     
     public function __construct($pdo)
         {

--- a/admin/src/database.class.php
+++ b/admin/src/database.class.php
@@ -27,7 +27,10 @@ $indexed = $db->runQuery("SELECT id, name FROM users")->fetchAll(PDO::FETCH_KEY_
 */
 class database {
 
-	public function __construct($pdo)
+    /** @var PDO */
+    private PDO $pdo;
+
+        public function __construct($pdo)
         {
             $this->pdo = $pdo;
         }

--- a/admin/src/login.class.php
+++ b/admin/src/login.class.php
@@ -1,8 +1,11 @@
 <?php
 class login {
+
+    /** @var PDO */
+    private PDO $pdo;
 	
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
     function checkLogin( $username, $hash ) {

--- a/admin/src/menulist.class.php
+++ b/admin/src/menulist.class.php
@@ -19,9 +19,12 @@ function active_session( $time = 600 ) {
 }
 */
 class menu {
+
+        /** @var PDO */
+        private PDO $pdo;
 	
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        function __construct($pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getGroups() {

--- a/src/analytics.php
+++ b/src/analytics.php
@@ -2,7 +2,7 @@
 class AdvancedAnalytics {
 
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/database.class.php
+++ b/src/database.class.php
@@ -28,7 +28,7 @@ $indexed = $db->runQuery("SELECT id, name FROM users")->fetchAll(PDO::FETCH_KEY_
 class database {
 
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
 
     public function __construct(PDO $pdo)
     {

--- a/src/site.class.php
+++ b/src/site.class.php
@@ -2,7 +2,7 @@
 class site {
 
     /** @var PDO */
-    private $pdo;
+    private PDO $pdo;
 
     public function __construct(PDO $pdo)
     {


### PR DESCRIPTION
## Summary
- declare PDO property for several classes to avoid dynamic property deprecation

## Testing
- `php -v`
- `php -l src/database.class.php`
- `php -l src/site.class.php`
- `php -l src/analytics.php`
- `php -l admin/src/analytics.class.php`
- `php -l admin/src/database.class.php`
- `php -l admin/src/login.class.php`
- `php -l admin/src/menulist.class.php`
- `php -l admin/modules/siteconfig/src/site_config.php`
- `php -l admin/modules/theme/src/theme.class.php`
- `php -l admin/modules/admin_users/src/admin_users.class.php`
- `php -l admin/modules/auctions/src/auction.class.php`
- `php -l admin/modules/banners/src/banners.class.php`
- `php -l admin/modules/carousel/src/carousel.class.php`
- `php -l admin/modules/content/src/content.class.php`
- `php -l admin/modules/gallery/src/gallery.class.php`
- `php -l admin/modules/keywords/src/keywords.class.php`
- `php -l admin/modules/reviews/src/review.class.php`


------
https://chatgpt.com/codex/tasks/task_e_684a0567c298832aaa3bcdc86de42745