### PR TITLE
Fix dynamic property deprecation in gallery class

### DIFF
--- a/functions/gallery.php
+++ b/functions/gallery.php
@@ -1,4 +1,5 @@
 <?php
+#[\AllowDynamicProperties]
 class gallery {
 
         private PDO $pdo;

--- a/themes/onepage/functions/gallery.php
+++ b/themes/onepage/functions/gallery.php
@@ -1,4 +1,5 @@
 <?php
+#[\AllowDynamicProperties]
 class gallery {
 
         private PDO $pdo;


### PR DESCRIPTION
## Summary
- allow dynamic properties on gallery class used by onepage theme and general functions

## Testing
- `php test.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab784ae58832a8880c1b481c21eb0