### PR TITLE
Fix AdvancedAnalytics PDO usage

### DIFF
--- a/src/analytics.php
+++ b/src/analytics.php
@@ -1,5 +1,12 @@
 <?php
 class AdvancedAnalytics {
+
+    private $pdo;
+
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
     
     public function startSession() {
         if (!isset($_SESSION['session_start_time'])) {


### PR DESCRIPTION
## Summary
- inject PDO dependency into AdvancedAnalytics

## Testing
- `php -l src/analytics.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684feb0ddd1c832aba8aff9c5e00865e