### PR TITLE
Fix PDO reference in site class

### DIFF
--- a/src/site.class.php
+++ b/src/site.class.php
@@ -1,5 +1,13 @@
 <?php
 class site {
+
+    /** @var PDO */
+    private $pdo;
+
+    public function __construct($pdo)
+    {
+        $this->pdo = $pdo;
+    }
     
     /* START GETTNG DATA FOR WEBSITES */
 	function getConfig ($loc_website) {


### PR DESCRIPTION
## Summary
- initialize `$pdo` in `site` class constructor to avoid undefined property errors

## Testing
- `php -l src/site.class.php`


------
https://chatgpt.com/codex/tasks/task_e_684ff3dfc9bc832a98f269f38f23290b