### PR TITLE
Ensure test_url_filtering uses associative fetch

### DIFF
--- a/admin/bin/test_url_filtering.php
+++ b/admin/bin/test_url_filtering.php
@@ -46,7 +46,7 @@ try {
         LIMIT 10
     ");
     $stmt->execute();
-    $suspiciousUrls = $stmt->fetchAll();
+    $suspiciousUrls = $stmt->fetchAll(PDO::FETCH_ASSOC);
     
     if (empty($suspiciousUrls)) {
         echo "<p style='color: green;'>✓ No suspicious URLs found in database.</p>";
@@ -69,7 +69,7 @@ try {
     // Show total records count
     $stmt = $pdo->prepare("SELECT COUNT(*) as total FROM analytics");
     $stmt->execute();
-    $totalRecords = $stmt->fetch()['total'];
+    $totalRecords = $stmt->fetch(PDO::FETCH_ASSOC)['total'];
     
     echo "<h3>Database Summary:</h3>";
     echo "<p>Total analytics records: " . $totalRecords . "</p>";


### PR DESCRIPTION
## Summary
- Use associative mode for database fetches in test_url_filtering

## Testing
- `php -l admin/bin/test_url_filtering.php`


------
https://chatgpt.com/codex/tasks/task_e_6895c916bca4832a9de8f6be6527eabd