### PR TITLE
Fix admin site selector and streamline analytics filters

### DIFF
--- a/admin/src/analytics.class.php
+++ b/admin/src/analytics.class.php
@@ -39,17 +39,18 @@ class Analytics {
     
     public function getAllSites() {
         try {
-            // Check if sites table exists
-            $stmt = $this->pdo->prepare("SHOW TABLES LIKE 'sites'");
+            // Check if config table exists (same source used by navbar)
+            $stmt = $this->pdo->prepare("SHOW TABLES LIKE 'config'");
             $stmt->execute();
-            
+
             if ($stmt->rowCount() == 0) {
                 return [['id' => 1, 'domain' => 'default', 'name' => 'Default Site']];
             }
-            
-            $stmt = $this->pdo->prepare("SELECT id, domain, name, description, status FROM sites WHERE status = 'active' ORDER BY name");
+
+            // Use config table to match site dropdown in navigation
+            $stmt = $this->pdo->prepare("SELECT id, loc_website AS domain, web_naam AS name FROM config ORDER BY web_naam");
             $stmt->execute();
-            return $stmt->fetchAll();
+            return $stmt->fetchAll(PDO::FETCH_ASSOC);
         } catch (Exception $e) {
             error_log("Error getting all sites: " . $e->getMessage());
             return [['id' => 1, 'domain' => 'default', 'name' => 'Default Site']];

--- a/admin/template/frontpage.php
+++ b/admin/template/frontpage.php
@@ -227,101 +227,70 @@ $stats = $analytics->getEnhancedStats(null, null, $currentSiteId);
 </style>
 
 <div class="container mt-5">
-  <!-- Site Selector Card - Top -->
+  <!-- Filters Card: Site & Datum Selectie -->
   <div class="row mb-4">
     <div class="col-12">
       <div class="card">
         <div class="card-header">
-          <h5><i class="bi bi-globe"></i> Site Selectie</h5>
+          <h5><i class="bi bi-sliders"></i> Site & Datum Selectie</h5>
         </div>
         <div class="card-body">
-          <div class="row">
-            <div class="col-md-6">
-              <div class="form-group">
-                <label for="siteSelector" class="form-label">
-                  <i class="bi bi-building"></i> Selecteer Website
-                </label>
-                <select id="siteSelector" name="site_id" class="form-control" onchange="changeSite()">
-                  <?php foreach ($sites as $site): ?>
-                    <option value="<?php echo $site['id']; ?>" <?php echo ($site['id'] == $currentSiteId) ? 'selected' : ''; ?>>
-                      <?php echo htmlspecialchars($site['name']); ?> (<?php echo htmlspecialchars($site['domain']); ?>)
-                    </option>
-                  <?php endforeach; ?>
-                </select>
-              </div>
+          <div class="row g-3 align-items-end">
+            <div class="col-lg-4 col-md-6">
+              <label for="siteSelector" class="form-label">
+                <i class="bi bi-building"></i> Selecteer Website
+              </label>
+              <select id="siteSelector" name="site_id" class="form-select" onchange="changeSite()">
+                <?php foreach ($sites as $site): ?>
+                  <option value="<?php echo $site['id']; ?>" <?php echo ($site['id'] == $currentSiteId) ? 'selected' : ''; ?>>
+                    <?php echo htmlspecialchars($site['name']); ?> (<?php echo htmlspecialchars($site['domain']); ?>)
+                  </option>
+                <?php endforeach; ?>
+              </select>
             </div>
-            <div class="col-md-6">
-              <div class="site-info">
-                <div class="info-display">
-                  <span class="info-label">Huidige site:</span>
-                  <span class="info-value" id="currentSiteDisplay">
-                    <?php 
-                    $currentSite = array_filter($sites, function($site) use ($currentSiteId) { return $site['id'] == $currentSiteId; });
-                    $currentSite = reset($currentSite);
-                    echo htmlspecialchars($currentSite['name'] ?? 'Onbekend'); 
-                    ?>
-                  </span>
-                </div>
-              </div>
+            <div class="col-lg-4 col-md-3">
+              <label for="startDate" class="form-label">
+                <i class="bi bi-calendar-event"></i> Begin Datum
+              </label>
+              <input type="date" id="startDate" name="startDate" class="form-control" value="<?php echo date('Y-m-01'); ?>" onchange="updateAllAnalytics()">
+            </div>
+            <div class="col-lg-4 col-md-3">
+              <label for="endDate" class="form-label">
+                <i class="bi bi-calendar-check"></i> Eind Datum
+              </label>
+              <input type="date" id="endDate" name="endDate" class="form-control" value="<?php echo date('Y-m-d'); ?>" onchange="updateAllAnalytics()">
             </div>
           </div>
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- Date Range Control Card - Top -->
-  <div class="row mb-4">
-    <div class="col-12">
-      <div class="card">
-        <div class="card-header">
-          <h5><i class="bi bi-calendar-range"></i> Datum Selectie</h5>
-        </div>
-        <div class="card-body">
-          <div class="row">
+          <div class="row mt-3">
             <div class="col-md-6">
-              <div class="date-range-container">
-                <div class="date-input-group">
-                  <label for="startDate" class="form-label">
-                    <i class="bi bi-calendar-event"></i> Begin Datum
-                  </label>
-                  <div class="input-wrapper">
-                    <input type="date" id="startDate" name="startDate" class="form-control date-input" value="<?php echo date('Y-m-01'); ?>" onchange="updateAllAnalytics()">
-                    <div class="date-slider-track"></div>
-                  </div>
-                </div>
-                
-                <div class="date-input-group">
-                  <label for="endDate" class="form-label">
-                    <i class="bi bi-calendar-check"></i> Eind Datum
-                  </label>
-                  <div class="input-wrapper">
-                    <input type="date" id="endDate" name="endDate" class="form-control date-input" value="<?php echo date('Y-m-d'); ?>" onchange="updateAllAnalytics()">
-                    <div class="date-slider-track"></div>
-                  </div>
-                </div>
+              <div class="info-display">
+                <span class="info-label">Huidige site:</span>
+                <span class="info-value" id="currentSiteDisplay">
+                  <?php
+                  $currentSite = array_filter($sites, function($site) use ($currentSiteId) { return $site['id'] == $currentSiteId; });
+                  $currentSite = reset($currentSite);
+                  echo htmlspecialchars($currentSite['name'] ?? 'Onbekend');
+                  ?>
+                </span>
               </div>
             </div>
-            
-            <div class="col-md-6">
-              <div class="date-range-info">
-                <div class="range-display">
-                  <span class="range-label">Geselecteerde periode:</span>
-                  <span class="range-value" id="dateRangeDisplay">
-                    <?php echo date('d-m-Y'); ?> tot <?php echo date('d-m-Y'); ?>
-                  </span>
-                </div>
-                <div class="range-actions">
-                  <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('today')">
-                    <i class="bi bi-calendar-day"></i> Vandaag
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('week')">
-                    <i class="bi bi-calendar-week"></i> Deze week
-                  </button>
-                  <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('month')">
-                    <i class="bi bi-calendar-month"></i> Deze maand
-                  </button>
-                </div>
+            <div class="col-md-6 text-md-end">
+              <div class="range-actions mb-2">
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('today')">
+                  <i class="bi bi-calendar-day"></i> Vandaag
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('week')">
+                  <i class="bi bi-calendar-week"></i> Deze week
+                </button>
+                <button type="button" class="btn btn-sm btn-outline-primary" onclick="setQuickRange('month')">
+                  <i class="bi bi-calendar-month"></i> Deze maand
+                </button>
+              </div>
+              <div class="range-display">
+                <span class="range-label">Geselecteerde periode:</span>
+                <span class="range-value" id="dateRangeDisplay">
+                  <?php echo date('d-m-Y'); ?> tot <?php echo date('d-m-Y'); ?>
+                </span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Fetch site list from `config` table so analytics page dropdown shows available sites
- Merge site selection and date range controls into one Bootstrap card for a cleaner layout

## Testing
- `php -l admin/src/analytics.class.php`
- `php -l admin/template/frontpage.php`


------
https://chatgpt.com/codex/tasks/task_e_689610d52868832a888471dbabfc3423