### PR TITLE
Add onepage checkout with Mollie integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ node_modules/
 # Cache directories
 .cache/
 *.cache
+vendor/

--- a/checkout.php
+++ b/checkout.php
@@ -1,0 +1,162 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Mollie\Api\MollieApiClient;
+
+$mollie = new MollieApiClient();
+// Gebruik een test API key van Mollie. Vervang deze met een live key in productie.
+$mollie->setApiKey('test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+$userId = $_SESSION['user_id'] ?? null;
+$errors = [];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'create_payment') {
+    $email = trim($_POST['email'] ?? '');
+    $amount = trim($_POST['amount'] ?? '10.00');
+
+    $billing = [
+        'street' => trim($_POST['billing_street'] ?? ''),
+        'postal_code' => trim($_POST['billing_postal'] ?? ''),
+        'city' => trim($_POST['billing_city'] ?? ''),
+        'country' => trim($_POST['billing_country'] ?? ''),
+    ];
+
+    $shipping = [
+        'street' => trim($_POST['shipping_street'] ?? ''),
+        'postal_code' => trim($_POST['shipping_postal'] ?? ''),
+        'city' => trim($_POST['shipping_city'] ?? ''),
+        'country' => trim($_POST['shipping_country'] ?? ''),
+    ];
+
+    if (!$email) {
+        $errors[] = 'E-mail is verplicht';
+    }
+
+    if (!$errors) {
+        try {
+            $payment = $mollie->payments->create([
+                'amount' => [
+                    'currency' => 'EUR',
+                    'value' => number_format((float)$amount, 2, '.', ''),
+                ],
+                'description' => 'Onepage checkout order',
+                'redirectUrl' => sprintf('https://%s/checkout.php?status=return', $_SERVER['HTTP_HOST']),
+                'webhookUrl' => sprintf('https://%s/mollie_webhook.php', $_SERVER['HTTP_HOST']),
+                'metadata' => [
+                    'email' => $email,
+                    'billing' => $billing,
+                    'shipping' => $shipping,
+                    'user_id' => $userId,
+                ],
+            ]);
+
+            $_SESSION['payment_id'] = $payment->id;
+            header('Location: ' . $payment->getCheckoutUrl());
+            exit;
+        } catch (\Exception $e) {
+            $errors[] = $e->getMessage();
+        }
+    }
+}
+
+if (($_GET['status'] ?? '') === 'return' && isset($_SESSION['payment_id'])) {
+    try {
+        $payment = $mollie->payments->get($_SESSION['payment_id']);
+        if ($payment->isPaid()) {
+            $message = 'Betaling geslaagd. Bedankt!';
+        } else {
+            $message = 'Betaling status: ' . htmlspecialchars($payment->status);
+        }
+    } catch (\Exception $e) {
+        $statusFile = __DIR__ . '/uploads/payment_' . $_SESSION['payment_id'] . '.json';
+        if (file_exists($statusFile)) {
+            $data = json_decode(file_get_contents($statusFile), true);
+            $message = 'Betaling status: ' . htmlspecialchars($data['status'] ?? 'onbekend');
+        } else {
+            $errors[] = $e->getMessage();
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="nl">
+<head>
+    <meta charset="UTF-8">
+    <title>Checkout</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        .error { color: red; }
+        .field { margin-bottom: 1em; }
+        .hidden { display: none; }
+    </style>
+    <script>
+    function toggleShipping() {
+        const useBilling = document.getElementById('use_billing').checked;
+        document.getElementById('shipping_fields').style.display = useBilling ? 'none' : 'block';
+    }
+    </script>
+</head>
+<body onload="toggleShipping()">
+<h1>Onepage Checkout</h1>
+<?php if ($userId): ?>
+<p>Ingelogd als gebruiker <?php echo htmlspecialchars($userId); ?></p>
+<?php else: ?>
+<p>Gast afrekenen</p>
+<?php endif; ?>
+<?php if ($errors): ?>
+    <div class="error">
+        <ul>
+            <?php foreach ($errors as $error): ?>
+                <li><?php echo htmlspecialchars($error); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </div>
+<?php endif; ?>
+<?php if ($message): ?>
+    <p><?php echo htmlspecialchars($message); ?></p>
+<?php endif; ?>
+<form method="post">
+    <input type="hidden" name="action" value="create_payment">
+    <div class="field">
+        <label>E-mail<br><input type="email" name="email" required value="<?php echo htmlspecialchars($_POST['email'] ?? '') ?>"></label>
+    </div>
+    <h2>Factuuradres</h2>
+    <div class="field">
+        <label>Straat<br><input type="text" name="billing_street" required value="<?php echo htmlspecialchars($_POST['billing_street'] ?? '') ?>"></label>
+    </div>
+    <div class="field">
+        <label>Postcode<br><input type="text" name="billing_postal" required value="<?php echo htmlspecialchars($_POST['billing_postal'] ?? '') ?>"></label>
+    </div>
+    <div class="field">
+        <label>Stad<br><input type="text" name="billing_city" required value="<?php echo htmlspecialchars($_POST['billing_city'] ?? '') ?>"></label>
+    </div>
+    <div class="field">
+        <label>Land<br><input type="text" name="billing_country" required value="<?php echo htmlspecialchars($_POST['billing_country'] ?? '') ?>"></label>
+    </div>
+    <div class="field">
+        <label><input type="checkbox" id="use_billing" name="use_billing" value="1" <?php echo isset($_POST['use_billing']) ? 'checked' : '' ?> onchange="toggleShipping()"> Verzenden naar factuuradres</label>
+    </div>
+    <div id="shipping_fields">
+        <h2>Afleveradres</h2>
+        <div class="field">
+            <label>Straat<br><input type="text" name="shipping_street" value="<?php echo htmlspecialchars($_POST['shipping_street'] ?? '') ?>"></label>
+        </div>
+        <div class="field">
+            <label>Postcode<br><input type="text" name="shipping_postal" value="<?php echo htmlspecialchars($_POST['shipping_postal'] ?? '') ?>"></label>
+        </div>
+        <div class="field">
+            <label>Stad<br><input type="text" name="shipping_city" value="<?php echo htmlspecialchars($_POST['shipping_city'] ?? '') ?>"></label>
+        </div>
+        <div class="field">
+            <label>Land<br><input type="text" name="shipping_country" value="<?php echo htmlspecialchars($_POST['shipping_country'] ?? '') ?>"></label>
+        </div>
+    </div>
+    <div class="field">
+        <label>Bedrag (EUR)<br><input type="number" step="0.01" name="amount" value="<?php echo htmlspecialchars($_POST['amount'] ?? '10.00') ?>"></label>
+    </div>
+    <button type="submit">Betaal</button>
+</form>
+</body>
+</html>

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "ajmweb/onepage-checkout",
+    "description": "Onepage Mollie checkout integration",
+    "license": "proprietary",
+    "require": {
+        "mollie/mollie-api-php": "^2.0"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,187 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "68a99bd3f5fef71f169d7df223ccaa0b",
+    "packages": [
+        {
+            "name": "composer/ca-bundle",
+            "version": "1.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/ca-bundle.git",
+                "reference": "d665d22c417056996c59019579f1967dfe5c1e82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d665d22c417056996c59019579f1967dfe5c1e82",
+                "reference": "d665d22c417056996c59019579f1967dfe5c1e82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-openssl": "*",
+                "ext-pcre": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^8 || ^9",
+                "psr/log": "^1.0 || ^2.0 || ^3.0",
+                "symfony/process": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\CaBundle\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Lets you find a path to the system CA bundle, and includes a fallback to the Mozilla CA bundle.",
+            "keywords": [
+                "cabundle",
+                "cacert",
+                "certificate",
+                "ssl",
+                "tls"
+            ],
+            "support": {
+                "irc": "irc://irc.freenode.org/composer",
+                "issues": "https://github.com/composer/ca-bundle/issues",
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.7"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-26T15:08:54+00:00"
+        },
+        {
+            "name": "mollie/mollie-api-php",
+            "version": "v2.79.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mollie/mollie-api-php.git",
+                "reference": "4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mollie/mollie-api-php/zipball/4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0",
+                "reference": "4c1cf5f603178dd15bdf60b5e3999f91bb59f5b0",
+                "shasum": ""
+            },
+            "require": {
+                "composer/ca-bundle": "^1.2",
+                "ext-curl": "*",
+                "ext-json": "*",
+                "ext-openssl": "*",
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "eloquent/liberator": "^2.0||^3.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "guzzlehttp/guzzle": "^6.3 || ^7.0",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5 || ^9.5"
+            },
+            "suggest": {
+                "mollie/oauth2-mollie-php": "Use OAuth to authenticate with the Mollie API. This is needed for some endpoints. Visit https://docs.mollie.com/ for more information."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Mollie\\Api\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Mollie B.V.",
+                    "email": "info@mollie.com"
+                }
+            ],
+            "description": "Mollie API client library for PHP. Mollie is a European Payment Service provider and offers international payment methods such as Mastercard, VISA, American Express and PayPal, and local payment methods such as iDEAL, Bancontact, SOFORT Banking, SEPA direct debit, Belfius Direct Net, KBC Payment Button and various gift cards such as Podiumcadeaukaart and fashioncheque.",
+            "homepage": "https://www.mollie.com/en/developers",
+            "keywords": [
+                "Apple Pay",
+                "CBC",
+                "Przelewy24",
+                "api",
+                "bancontact",
+                "banktransfer",
+                "belfius",
+                "belfius direct net",
+                "charges",
+                "creditcard",
+                "direct debit",
+                "fashioncheque",
+                "gateway",
+                "gift cards",
+                "ideal",
+                "inghomepay",
+                "intersolve",
+                "kbc",
+                "klarna",
+                "mistercash",
+                "mollie",
+                "paylater",
+                "payment",
+                "payments",
+                "paypal",
+                "paysafecard",
+                "podiumcadeaukaart",
+                "recurring",
+                "refunds",
+                "sepa",
+                "service",
+                "sliceit",
+                "sofort",
+                "sofortbanking",
+                "subscriptions"
+            ],
+            "support": {
+                "issues": "https://github.com/mollie/mollie-api-php/issues",
+                "source": "https://github.com/mollie/mollie-api-php/tree/v2.79.1"
+            },
+            "time": "2025-05-06T10:55:09+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/mollie_webhook.php
+++ b/mollie_webhook.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/vendor/autoload.php';
+
+use Mollie\Api\MollieApiClient;
+
+$mollie = new MollieApiClient();
+$mollie->setApiKey('test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+$paymentId = $_POST['id'] ?? null;
+if ($paymentId) {
+    try {
+        $payment = $mollie->payments->get($paymentId);
+        // Sla status op in een eenvoudig bestand zodat deze later kan worden opgehaald
+        $statusFile = __DIR__ . '/uploads/payment_' . $paymentId . '.json';
+        file_put_contents($statusFile, json_encode([
+            'status' => $payment->status,
+            'amount' => $payment->amount->value,
+            'updated' => date('c'),
+        ]));
+    } catch (\Exception $e) {
+        // Eventuele fouten loggen
+        error_log($e->getMessage());
+    }
+}
+http_response_code(200);


### PR DESCRIPTION
## Summary
- add composer setup and Mollie PHP API dependency
- implement one-page checkout with billing/shipping details and guest/user support
- add webhook handler to persist Mollie payment status

## Testing
- `composer validate --no-check-lock`
- `php -l checkout.php`
- `php -l mollie_webhook.php`


------
https://chatgpt.com/codex/tasks/task_e_6898ed6e750c832ab42dd9497e624686