### PR TITLE
Add admin orders management skeleton

### DIFF
--- a/admin/modules/orders/bin/export.php
+++ b/admin/modules/orders/bin/export.php
@@ -1,0 +1,29 @@
+<?php
+$path = $_SERVER['DOCUMENT_ROOT'];
+if (!isset($db)) {
+    require_once($path . "/system/database.php");
+    require_once($path . "/admin/src/database.class.php");
+    $db = new database($pdo);
+}
+require_once($path . "/admin/modules/orders/src/orders.class.php");
+
+$orders = new orders($pdo);
+$carrier = isset($_GET['carrier']) ? $_GET['carrier'] : 'postnl';
+$list = $orders->getOrdersForCarrier($carrier);
+
+header('Content-Type: text/csv');
+header('Content-Disposition: attachment; filename="' . $carrier . '_orders.csv"');
+
+$fh = fopen('php://output', 'w');
+fputcsv($fh, ['id', 'customer_name', 'address', 'zip', 'city', 'country']);
+foreach ($list as $row) {
+    fputcsv($fh, [
+        $row['id'],
+        $row['customer_name'],
+        $row['address'],
+        $row['zip'],
+        $row['city'],
+        $row['country']
+    ]);
+}
+fclose($fh);

--- a/admin/modules/orders/bin/summary.php
+++ b/admin/modules/orders/bin/summary.php
@@ -1,0 +1,55 @@
+<?php
+$path = $_SERVER['DOCUMENT_ROOT'];
+if (!isset($db)) {
+    require_once($path . "/system/database.php");
+    require_once($path . "/admin/src/database.class.php");
+    $db = new database($pdo);
+}
+require_once($path . "/admin/modules/orders/src/orders.class.php");
+
+$orders = new orders($pdo);
+$page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
+$perPage = 10;
+$offset = ($page - 1) * $perPage;
+$list = $orders->getOrders($offset, $perPage);
+$total = $orders->countOrders();
+$totalPages = $perPage > 0 ? ceil($total / $perPage) : 1;
+?>
+<table class="table">
+  <thead>
+    <tr>
+      <th>ID</th>
+      <th>Klant</th>
+      <th>Status</th>
+      <th>Factuur</th>
+      <th>Acties</th>
+    </tr>
+  </thead>
+  <tbody>
+  <?php foreach ($list as $order) { ?>
+    <tr>
+      <td><?php echo $order['id']; ?></td>
+      <td><?php echo htmlspecialchars($order['customer_name']); ?></td>
+      <td>
+        <select class="form-select form-select-sm status-select" data-id="<?php echo $order['id']; ?>">
+          <?php $statuses = ['new','processing','shipped','completed'];
+          foreach ($statuses as $s) { ?>
+            <option value="<?php echo $s; ?>" <?php if ($order['status'] === $s) echo 'selected'; ?>><?php echo ucfirst($s); ?></option>
+          <?php } ?>
+        </select>
+      </td>
+      <td><a href="<?php echo $order['invoice_pdf']; ?>" target="_blank">Download</a></td>
+      <td></td>
+    </tr>
+  <?php } ?>
+  </tbody>
+</table>
+<nav>
+  <ul class="pagination">
+    <?php for ($i = 1; $i <= $totalPages; $i++) { ?>
+      <li class="page-item<?php if ($i == $page) echo ' active'; ?>">
+        <a class="page-link" href="#" data-page="<?php echo $i; ?>"><?php echo $i; ?></a>
+      </li>
+    <?php } ?>
+  </ul>
+</nav>

--- a/admin/modules/orders/bin/update_status.php
+++ b/admin/modules/orders/bin/update_status.php
@@ -1,0 +1,18 @@
+<?php
+header('Content-Type: application/json');
+$path = $_SERVER['DOCUMENT_ROOT'];
+if (!isset($db)) {
+    require_once($path . "/system/database.php");
+    require_once($path . "/admin/src/database.class.php");
+    $db = new database($pdo);
+}
+require_once($path . "/admin/modules/orders/src/orders.class.php");
+
+$orders = new orders($pdo);
+$id = isset($_POST['id']) ? (int)$_POST['id'] : 0;
+$status = isset($_POST['status']) ? $_POST['status'] : '';
+$success = false;
+if ($id && $status !== '') {
+    $success = $orders->updateStatus($id, $status);
+}
+echo json_encode(['success' => $success]);

--- a/admin/modules/orders/index.php
+++ b/admin/modules/orders/index.php
@@ -1,0 +1,27 @@
+<?php
+// Admin orders module main page
+?>
+<h2>Bestellingen</h2>
+<div class="mb-3">
+  <button id="export_postnl" class="btn btn-sm btn-secondary">Export PostNL CSV</button>
+  <button id="export_dhl" class="btn btn-sm btn-secondary">Export DHL CSV</button>
+</div>
+<div class="row mt-4">
+  <div class="col-md-12">
+    <div class="card shadow">
+      <div class="card-header">
+        <div class="row">
+          <div class="col-2"><h5>Ordernr</h5></div>
+          <div class="col-3"><h5>Klant</h5></div>
+          <div class="col-2"><h5>Status</h5></div>
+          <div class="col-3"><h5>Factuur</h5></div>
+          <div class="col-2 text-end"><h5>Acties</h5></div>
+        </div>
+      </div>
+      <div class="card-body">
+        <div id="orderlist"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="/admin/modules/orders/js/orders.js" type="text/javascript"></script>

--- a/admin/modules/orders/js/orders.js
+++ b/admin/modules/orders/js/orders.js
@@ -1,0 +1,26 @@
+$(function(){
+    function load(page){
+        $("#orderlist").load("/admin/modules/orders/bin/summary.php?page="+page);
+    }
+    load(1);
+
+    $("#orderlist").on("click", ".pagination a", function(e){
+        e.preventDefault();
+        var page = $(this).data("page");
+        load(page);
+    });
+
+    $("#orderlist").on("change", ".status-select", function(){
+        var id = $(this).data("id");
+        var status = $(this).val();
+        $.post("/admin/modules/orders/bin/update_status.php", {id:id, status:status});
+    });
+
+    $("#export_postnl").on("click", function(){
+        window.location = "/admin/modules/orders/bin/export.php?carrier=postnl";
+    });
+
+    $("#export_dhl").on("click", function(){
+        window.location = "/admin/modules/orders/bin/export.php?carrier=dhl";
+    });
+});

--- a/admin/modules/orders/src/orders.class.php
+++ b/admin/modules/orders/src/orders.class.php
@@ -1,0 +1,37 @@
+<?php
+class orders {
+    private $pdo;
+    public function __construct(PDO $pdo) {
+        $this->pdo = $pdo;
+    }
+
+    public function getOrders($offset = 0, $limit = 10) {
+        $sql = "SELECT * FROM orders ORDER BY created_at DESC LIMIT :limit OFFSET :offset";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->bindValue(':limit', (int)$limit, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', (int)$offset, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function countOrders() {
+        $sql = "SELECT COUNT(*) as cnt FROM orders";
+        $stmt = $this->pdo->query($sql);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return (int)$row['cnt'];
+    }
+
+    public function updateStatus($id, $status) {
+        $sql = "UPDATE orders SET status = :status WHERE id = :id";
+        $stmt = $this->pdo->prepare($sql);
+        return $stmt->execute(['status' => $status, 'id' => $id]);
+    }
+
+    public function getOrdersForCarrier($carrier) {
+        $sql = "SELECT * FROM orders WHERE carrier = :carrier";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['carrier' => $carrier]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/admin/template/navbar.php
+++ b/admin/template/navbar.php
@@ -57,6 +57,7 @@ $daytime = $login->daytime(date("H"));
                 <li><a class="dropdown-item" aria-current="newsletter_memberlist" href="/admin/newsletter_memberlist/">Nieuwsbrief leden</a></li>
                 <li><a class="dropdown-item" aria-current="newsletter" href="/admin/newsletter/">Nieuwsbrief</a></li>
                 <li><a class="dropdown-item" aria-current="customers" href="/admin/customers/">Klanten</a></li>
+                <li><a class="dropdown-item" aria-current="orders" href="/admin/orders/">Bestellingen</a></li>
             </ul>
         </li>
 


### PR DESCRIPTION
## Summary
- Add basic Orders module in admin area with AJAX-driven list, status updates, PDF invoice links, and carrier-specific CSV exports.
- Link Orders module in admin navigation.

## Testing
- `php -l admin/modules/orders/index.php`
- `php -l admin/modules/orders/src/orders.class.php`
- `php -l admin/modules/orders/bin/summary.php`
- `php -l admin/modules/orders/bin/update_status.php`
- `php -l admin/modules/orders/bin/export.php`
- `php -l admin/template/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_6898eded62cc832aa7998c95199aa675