### PR TITLE
Add demo product page with cart and favorites

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -1,10 +1,11 @@
 $(function() {
   const placeholderImage = 'https://via.placeholder.com/60x60?text=No+Image';
 
-  let cart = [
-    { id: 1, name: 'Product A', price: 10.00, quantity: 1, image: '' },
-    { id: 2, name: 'Product B', price: 15.50, quantity: 2, image: 'https://via.placeholder.com/60' }
-  ];
+  let cart = JSON.parse(localStorage.getItem('cart')) || [];
+
+  function saveCart() {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }
 
   function renderCart() {
     const $tbody = $('#cartTable tbody');
@@ -36,6 +37,7 @@ $(function() {
     });
 
     $('#grandTotal').text('€' + grandTotal.toFixed(2));
+    saveCart();
   }
 
   function updateQuantity(id, delta) {

--- a/js/product-page.js
+++ b/js/product-page.js
@@ -1,0 +1,65 @@
+$(function() {
+  function getCart() {
+    return JSON.parse(localStorage.getItem('cart')) || [];
+  }
+  function saveCart(cart) {
+    localStorage.setItem('cart', JSON.stringify(cart));
+  }
+  function getFavorites() {
+    return JSON.parse(localStorage.getItem('favorites')) || [];
+  }
+  function saveFavorites(favs) {
+    localStorage.setItem('favorites', JSON.stringify(favs));
+  }
+
+  $('.btn-cart').on('click', function() {
+    const $btn = $(this);
+    const product = {
+      id: $btn.data('id'),
+      name: $btn.data('name'),
+      price: parseFloat($btn.data('price')),
+      image: $btn.data('image'),
+      quantity: 1
+    };
+    let cart = getCart();
+    const existing = cart.find(i => i.id === product.id);
+    if (existing) {
+      existing.quantity += 1;
+    } else {
+      cart.push(product);
+    }
+    saveCart(cart);
+    $btn.addClass('clicked').text('Toegevoegd');
+  });
+
+  $('.btn-fav').on('click', function() {
+    const $btn = $(this);
+    const id = $btn.data('id');
+    let favs = getFavorites();
+    const index = favs.indexOf(id);
+    if (index === -1) {
+      favs.push(id);
+      $btn.addClass('clicked');
+    } else {
+      favs.splice(index, 1);
+      $btn.removeClass('clicked');
+    }
+    saveFavorites(favs);
+  });
+
+  function filterProducts() {
+    const search = $('#search').val().toLowerCase();
+    const categories = $('.category-filter:checked').map(function(){return this.value;}).get();
+    $('.product-card').each(function(){
+      const $card = $(this);
+      const title = $card.find('.card-title').text().toLowerCase();
+      const category = $card.data('category');
+      const matchSearch = title.includes(search);
+      const matchCategory = categories.length === 0 || categories.includes(category);
+      $card.toggle(matchSearch && matchCategory);
+    });
+  }
+
+  $('#search').on('keyup', filterProducts);
+  $('.category-filter').on('change', filterProducts);
+});

--- a/modules/product_page.php
+++ b/modules/product_page.php
@@ -1,0 +1,72 @@
+<?php
+// Simple demo product page module with sidebar filters and four products
+?>
+<div class="container py-5">
+  <div class="row">
+    <aside class="col-md-3 mb-4">
+      <h4 class="mb-3">Zoek</h4>
+      <input type="text" id="search" class="form-control mb-4" placeholder="Zoek...">
+      <h5>Categorieën</h5>
+      <div class="form-check">
+        <input class="form-check-input category-filter" type="checkbox" value="electronics" id="cat1">
+        <label class="form-check-label" for="cat1">Elektronica</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input category-filter" type="checkbox" value="books" id="cat2">
+        <label class="form-check-label" for="cat2">Boeken</label>
+      </div>
+      <div class="form-check">
+        <input class="form-check-input category-filter" type="checkbox" value="home" id="cat3">
+        <label class="form-check-label" for="cat3">Huis</label>
+      </div>
+    </aside>
+    <div class="col-md-9">
+      <div class="row" id="product-list">
+        <div class="col-md-6 mb-4 product-card" data-category="electronics">
+          <div class="card h-100">
+            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 1">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">Product 1</h5>
+              <p class="card-text mb-4">&euro;10,00</p>
+              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="1" data-name="Product 1" data-price="10" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
+              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="1">Favoriet</button>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 mb-4 product-card" data-category="books">
+          <div class="card h-100">
+            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 2">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">Product 2</h5>
+              <p class="card-text mb-4">&euro;15,50</p>
+              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="2" data-name="Product 2" data-price="15.5" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
+              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="2">Favoriet</button>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 mb-4 product-card" data-category="home">
+          <div class="card h-100">
+            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 3">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">Product 3</h5>
+              <p class="card-text mb-4">&euro;7,25</p>
+              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="3" data-name="Product 3" data-price="7.25" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
+              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="3">Favoriet</button>
+            </div>
+          </div>
+        </div>
+        <div class="col-md-6 mb-4 product-card" data-category="electronics">
+          <div class="card h-100">
+            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 4">
+            <div class="card-body d-flex flex-column">
+              <h5 class="card-title">Product 4</h5>
+              <p class="card-text mb-4">&euro;22,00</p>
+              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="4" data-name="Product 4" data-price="22" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
+              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="4">Favoriet</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/productpage.php
+++ b/productpage.php
@@ -1,0 +1,41 @@
+<?php require_once("config.php"); ?>
+<!DOCTYPE html>
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title><?php echo $title; ?> | producten</title>
+  <meta content="<?php echo $meta_description; ?>" name="description">
+  <meta content="<?php echo $meta_keywords; ?>" name="keywords">
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+
+  <!-- Favicons -- >
+  <link href="themes/onepage/assets/img/favicon.png" rel="icon">
+  <link href="themes/onepage/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Dosis:300,400,500,,600,700,700i|Lato:300,300i,400,400i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!--- Template Main CSS File -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/style.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/product-page.css" rel="stylesheet">
+</head>
+
+<body>
+<div id="display" class="alert-fixed"></div>
+<?php
+require_once($theme."/sections/header.php");
+require_once($_SERVER['DOCUMENT_ROOT']."/modules/product_page.php");
+require_once($theme."/sections/footer.php");
+?>
+<script src="js/product-page.js"></script>
+</body>
+</html>

--- a/themes/onepage/assets/css/product-page.css
+++ b/themes/onepage/assets/css/product-page.css
@@ -1,0 +1,16 @@
+.sidebar {
+  border-right: 1px solid #ddd;
+}
+
+.btn-interactive {
+  transition: transform 0.2s, background-color 0.2s;
+}
+
+.btn-interactive:hover {
+  transform: scale(1.05);
+}
+
+.btn-interactive.clicked {
+  background-color: #198754;
+  color: #fff;
+}


### PR DESCRIPTION
## Summary
- add product overview page with search sidebar and four demo products
- enable front-end cart and favorites storage with interactive buttons
- persist cart items via localStorage on cart page

## Testing
- `php -l productpage.php`
- `php -l modules/product_page.php`
- `node --check js/product-page.js`
- `node --check js/cart.js`


------
https://chatgpt.com/codex/tasks/task_e_689d152c80d0832abcfa4f4fefe35e24