### PR TITLE
Declare PDO property in review class

### DIFF
--- a/admin/modules/reviews/src/review.class.php
+++ b/admin/modules/reviews/src/review.class.php
@@ -1,6 +1,8 @@
 <?php
 class review {
-	
+
+    private PDO $pdo;
+
 /*
 id
 subject
@@ -13,8 +15,8 @@ reviewdate
 modified
 active
 */
-	function __construct($pdo) {
-		$this->pdo = $pdo;
+        function __construct(PDO $pdo) {
+                $this->pdo = $pdo;
     }
 
 	function getAllReviews() {


### PR DESCRIPTION
## Summary
- declare `PDO` property and type-hint constructor in `review` class to avoid deprecated dynamic property warning

## Testing
- `php -l admin/modules/reviews/src/review.class.php`


------
https://chatgpt.com/codex/tasks/task_e_689db4b4b77c832a8e14741b511448c1