### PR TITLE
Add product CRUD module and tables

### DIFF
--- a/admin/modules/products/delete.php
+++ b/admin/modules/products/delete.php
@@ -1,0 +1,12 @@
+<?php
+$path = $_SERVER['DOCUMENT_ROOT'];
+require_once $path . '/system/database.php';
+
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+if ($id) {
+    $stmt = $pdo->prepare('DELETE FROM products WHERE id=?');
+    $stmt->execute([$id]);
+}
+header('Location: ?module=products&action=list');
+exit;
+?>

--- a/admin/modules/products/edit.php
+++ b/admin/modules/products/edit.php
@@ -1,105 +1,90 @@
 <?php
-require_once("src/products.class.php"); 
+$path = $_SERVER['DOCUMENT_ROOT'];
+require_once $path . '/system/database.php';
 
-if(!isset($_GET['id'])) { echo "oeps"; } else { $id = $_GET['id']; }
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
 
-$products = new products($pdo);	
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = $_POST['name'] ?? '';
+    $price = $_POST['price'] ?? 0;
+    $category_id = !empty($_POST['category_id']) ? (int)$_POST['category_id'] : null;
+    $description = $_POST['description'] ?? '';
+    $active = isset($_POST['active']) ? 1 : 0;
+    $variant = $_POST['variant'] ?? null;
+    $image_url = $_POST['image_url'] ?? null;
 
-// Debug informatie
-echo "<!-- Debug: ID = {$id} -->";
+    if ($id) {
+        $stmt = $pdo->prepare("UPDATE products SET name=?, price=?, category_id=?, description=?, active=? WHERE id=?");
+        $stmt->execute([$name, $price, $category_id, $description, $active, $id]);
+        $pdo->prepare("DELETE FROM product_images WHERE product_id=?")->execute([$id]);
+    } else {
+        $stmt = $pdo->prepare("INSERT INTO products (name, price, category_id, description, active) VALUES (?,?,?,?,?)");
+        $stmt->execute([$name, $price, $category_id, $description, $active]);
+        $id = $pdo->lastInsertId();
+    }
 
-$result = $products->getProductInfo( $id );
+    if ($image_url) {
+        $stmt = $pdo->prepare("INSERT INTO product_images (product_id, image_url, variant) VALUES (?,?,?)");
+        $stmt->execute([$id, $image_url, $variant]);
+    }
 
-if (!$result || empty($result)) {
-    echo '<div class="alert alert-danger">Product niet gevonden voor ID: ' . htmlspecialchars($id) . '</div>';
-    echo '<a href="/admin/products/" class="btn btn-secondary">Terug naar overzicht</a>';
+    header('Location: ?module=products&action=list');
     exit;
 }
 
-foreach ( $result as $data => $row ) {	
-
-$id 		   = $row['id'];
-$productCode   = $row['productCode'];
-$price         = $row['price'];
-$hash 		   = $row['hash'];
-$title	       = $row['title'];
-$seoTitle	   = $row['seoTitle'];
-$sort_num      = $row['sort_num'];
-$image     	   = $row['image'];
-$description   = $row['description'];
-$category      = $row['category'];
-$stock         = $row['stock'];
-$btw         = $row['btw'];
+$product = ['name' => '', 'price' => '', 'category_id' => '', 'description' => '', 'active' => 1, 'variant' => '', 'image_url' => ''];
+if ($id) {
+    $stmt = $pdo->prepare("SELECT * FROM products WHERE id=?");
+    $stmt->execute([$id]);
+    $product = $stmt->fetch(PDO::FETCH_ASSOC);
+    $img = $pdo->prepare("SELECT * FROM product_images WHERE product_id=? ORDER BY sort_order ASC LIMIT 1");
+    $img->execute([$id]);
+    $imgRow = $img->fetch(PDO::FETCH_ASSOC);
+    if ($imgRow) {
+        $product['variant'] = $imgRow['variant'];
+        $product['image_url'] = $imgRow['image_url'];
+    }
 }
 
-$img = $products->getImageName($id );
+$categories = $pdo->query("SELECT id, name FROM product_categories ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
 ?>
-<div id="menuList"></div>
-<div class="row mt-4" id="add_space">
-		
-	<div class="col-md-12">
-		<div class="float-end"><a href="/admin/products/" class="btn btn-dark">Terug</a></div>
-		<h2>Product bewerken</h2>
-	</div>
-	
-</div>
-
-<div class="row mt-4">
-		
-	<div class="col-md-12">
-		<?php include_once("forms/edit.php"); ?>
-	</div>
-	
-</div>
-
-<!-- Modal -->
-<div class="modal fade" id="dialogModal" tabindex="-1" aria-labelledby="dialogModalLabel" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="dialogModalLabel">Let op!</h5>
-        <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
-      </div>
-      <div class="modal-body">
-        <p class="text-center dialogmessage"></p>
-      </div>
-      <div class="modal-footer">
-        <input type="hidden" class="RowId" value="" id="RowId">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuleren</button>
-        <button type="button" class="btn btn-danger image-delete btn-ok" data-bs-dismiss="modal">Verwijderen</button>
-      </div>
-    </div>
+<h2><?= $id ? 'Product bewerken' : 'Nieuw product' ?></h2>
+<form method="post">
+  <div class="mb-3">
+    <label class="form-label">Naam</label>
+    <input type="text" name="name" class="form-control" value="<?= htmlspecialchars($product['name']) ?>" required>
   </div>
-</div>
-
-<script src="/admin/modules/products/js/imageupload.js"  type="text/javascript"></script>
-<script>
-   //afbeeldingen sorteren   
-
-    var grid = document.getElementById('imageContainer');
-    Sortable.create(grid, {
-        animation: 450,
-        onUpdate: function(evt) {
-            // Verzamelen van de nieuwe volgorde
-            var order = [];
-            var items = grid.querySelectorAll(".sortable-item");  // Verander .sortable-item naar de juiste klasse
-            items.forEach(function(item, index){
-                order.push(item.getAttribute("data-set")); // Haal het unieke id uit het data-set attribuut
-            });
-
-            // Versturen van de nieuwe volgorde via AJAX
-            $.ajax({
-                url: '/admin/modules/products/bin/image_sort.php', // jouw PHP-bestand
-                type: 'POST',
-                data: { order: order }, // Noteer de veranderde data structuur
-                success: function(response) {
-                    console.log("Succes: ", response);
-                },
-                error: function(error){
-                    console.log("Fout: ", error);
-                }
-            });
-        }
-    });
-</script>
-
+  <div class="mb-3">
+    <label class="form-label">Prijs</label>
+    <input type="number" step="0.01" name="price" class="form-control" value="<?= htmlspecialchars($product['price']) ?>" required>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Categorie</label>
+    <select name="category_id" class="form-select">
+      <option value="">--</option>
+      <?php foreach ($categories as $c): ?>
+      <option value="<?= $c['id'] ?>" <?= $c['id'] == $product['category_id'] ? 'selected' : '' ?>><?= htmlspecialchars($c['name']) ?></option>
+      <?php endforeach; ?>
+    </select>
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Beschrijving</label>
+    <textarea name="description" class="form-control" rows="4"><?= htmlspecialchars($product['description']) ?></textarea>
+  </div>
+  <div class="form-check mb-3">
+    <input class="form-check-input" type="checkbox" name="active" id="active" <?= $product['active'] ? 'checked' : '' ?>>
+    <label class="form-check-label" for="active">Actief</label>
+  </div>
+  <hr>
+  <h5>Variant</h5>
+  <div class="mb-3">
+    <label class="form-label">Variant naam</label>
+    <input type="text" name="variant" class="form-control" value="<?= htmlspecialchars($product['variant']) ?>">
+  </div>
+  <div class="mb-3">
+    <label class="form-label">Afbeelding URL</label>
+    <input type="text" name="image_url" class="form-control" value="<?= htmlspecialchars($product['image_url']) ?>">
+  </div>
+  <button type="submit" class="btn btn-primary">Opslaan</button>
+  <a href="?module=products&action=list" class="btn btn-secondary">Annuleren</a>
+</form>

--- a/admin/modules/products/index.php
+++ b/admin/modules/products/index.php
@@ -1,43 +1,16 @@
 <?php
-// Debug informatie
-echo "<!-- Debug: Module = {$module}, Action = {$action}, ID = {$id} -->";
+// Simple router for products admin module
+$action = isset($action) ? $action : ($_GET['action'] ?? 'list');
 
-if ($module == 'products' && $action == 'edit') { ?>
-
-<?php require_once("edit.php"); ?>
-
-<?php } else { ?>
-
-<h2>Product beheer</h2>
-<?php require_once("forms/add.php"); ?>
-<div class="row mt-4">
-  <div class="col-md-12">
-    <div class="card shadow">
-    <div class="card-header">
-        <div class="row">
-            <div class="col-1"></div>
-              <div class="col-4">
-                <h5>Naam</h5>
-              </div>
-              <div class="col-1">
-                <h5>Kavelnr.</h5>
-              </div>              
-            <div class="col-3">
-                <h5>Categorie</h5>
-              </div>
-              <div class="col-1"><h5>Aan/uit</h5></div>
-              <div class="col-2 text-end"><h5>Acties</h5></div>
-            </div>
-        </div>
-      
-      <div class="card-body">
-      <div id="menulist">
-        <?php include("bin/summary.php"); ?>
-          
-      </div>
-    </div>
-  </div>
-</div>
-<?php } ?>
-
-<script src="/admin/modules/products/js/menulist.js" type="text/javascript"></script>
+switch ($action) {
+    case 'edit':
+        require __DIR__ . '/edit.php';
+        break;
+    case 'delete':
+        require __DIR__ . '/delete.php';
+        break;
+    default:
+        require __DIR__ . '/list.php';
+        break;
+}
+?>

--- a/admin/modules/products/list.php
+++ b/admin/modules/products/list.php
@@ -1,0 +1,32 @@
+<?php
+$path = $_SERVER['DOCUMENT_ROOT'];
+require_once $path . '/system/database.php';
+
+$sql = "SELECT p.id, p.name, p.price, p.active, c.name AS category
+        FROM products p
+        LEFT JOIN product_categories c ON p.category_id = c.id
+        ORDER BY p.id DESC";
+$products = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
+?>
+<h2>Producten</h2>
+<a href="?module=products&action=edit" class="btn btn-primary mb-3">Nieuw product</a>
+<table class="table table-striped">
+  <thead>
+    <tr><th>ID</th><th>Naam</th><th>Categorie</th><th>Prijs</th><th>Actief</th><th>Acties</th></tr>
+  </thead>
+  <tbody>
+  <?php foreach ($products as $p): ?>
+    <tr>
+      <td><?= htmlspecialchars($p['id']) ?></td>
+      <td><?= htmlspecialchars($p['name']) ?></td>
+      <td><?= htmlspecialchars($p['category']) ?></td>
+      <td>&euro;<?= number_format($p['price'], 2, ',', '.') ?></td>
+      <td><?= $p['active'] ? 'Ja' : 'Nee' ?></td>
+      <td>
+        <a href="?module=products&action=edit&id=<?= $p['id'] ?>" class="btn btn-sm btn-primary">Bewerk</a>
+        <a href="?module=products&action=delete&id=<?= $p['id'] ?>" class="btn btn-sm btn-danger" onclick="return confirm('Verwijder product?');">Verwijder</a>
+      </td>
+    </tr>
+  <?php endforeach; ?>
+  </tbody>
+</table>

--- a/cron/create_product_tables.php
+++ b/cron/create_product_tables.php
@@ -1,0 +1,41 @@
+<?php
+// Script to create product-related tables
+$path = $_SERVER['DOCUMENT_ROOT'];
+require_once $path . '/system/database.php';
+
+try {
+    // Product categories
+    $pdo->exec("CREATE TABLE IF NOT EXISTS product_categories (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(255) NOT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    // Products
+    $pdo->exec("CREATE TABLE IF NOT EXISTS products (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        category_id INT NULL,
+        name VARCHAR(255) NOT NULL,
+        description TEXT,
+        price DECIMAL(10,2) NOT NULL DEFAULT 0,
+        active TINYINT(1) NOT NULL DEFAULT 1,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        FOREIGN KEY (category_id) REFERENCES product_categories(id) ON DELETE SET NULL
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    // Product images / variants
+    $pdo->exec("CREATE TABLE IF NOT EXISTS product_images (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        product_id INT NOT NULL,
+        image_url VARCHAR(255) NOT NULL,
+        variant VARCHAR(255) DEFAULT NULL,
+        sort_order INT DEFAULT 0,
+        FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE CASCADE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci");
+
+    echo "✅ Product tables created or already exist.";
+} catch (PDOException $e) {
+    echo '❌ Error: ' . $e->getMessage();
+}
+?>

--- a/modules/product_page.php
+++ b/modules/product_page.php
@@ -1,5 +1,17 @@
 <?php
-// Simple demo product page module with sidebar filters and four products
+$path = $_SERVER['DOCUMENT_ROOT'];
+require_once $path . '/system/database.php';
+
+// Fetch categories
+$categories = $pdo->query("SELECT id, name FROM product_categories ORDER BY name")->fetchAll(PDO::FETCH_ASSOC);
+
+// Fetch products with first image/variant
+$sql = "SELECT p.id, p.name, p.price, c.name AS category, i.image_url, i.variant
+        FROM products p
+        LEFT JOIN product_categories c ON p.category_id = c.id
+        LEFT JOIN product_images i ON p.id = i.product_id AND i.sort_order = 0
+        WHERE p.active = 1";
+$products = $pdo->query($sql)->fetchAll(PDO::FETCH_ASSOC);
 ?>
 <div class="container py-5">
   <div class="row">
@@ -7,65 +19,28 @@
       <h4 class="mb-3">Zoek</h4>
       <input type="text" id="search" class="form-control mb-4" placeholder="Zoek...">
       <h5>Categorieën</h5>
+      <?php foreach ($categories as $cat): ?>
       <div class="form-check">
-        <input class="form-check-input category-filter" type="checkbox" value="electronics" id="cat1">
-        <label class="form-check-label" for="cat1">Elektronica</label>
+        <input class="form-check-input category-filter" type="checkbox" value="<?= htmlspecialchars($cat['name']) ?>" id="cat<?= $cat['id'] ?>">
+        <label class="form-check-label" for="cat<?= $cat['id'] ?>"><?= htmlspecialchars($cat['name']) ?></label>
       </div>
-      <div class="form-check">
-        <input class="form-check-input category-filter" type="checkbox" value="books" id="cat2">
-        <label class="form-check-label" for="cat2">Boeken</label>
-      </div>
-      <div class="form-check">
-        <input class="form-check-input category-filter" type="checkbox" value="home" id="cat3">
-        <label class="form-check-label" for="cat3">Huis</label>
-      </div>
+      <?php endforeach; ?>
     </aside>
     <div class="col-md-9">
       <div class="row" id="product-list">
-        <div class="col-md-6 mb-4 product-card" data-category="electronics">
+        <?php foreach ($products as $p): ?>
+        <div class="col-md-6 mb-4 product-card" data-category="<?= htmlspecialchars($p['category']) ?>">
           <div class="card h-100">
-            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 1">
+            <img src="<?= htmlspecialchars($p['image_url'] ?: 'https://via.placeholder.com/300x200') ?>" class="card-img-top" alt="<?= htmlspecialchars($p['name']) ?>">
             <div class="card-body d-flex flex-column">
-              <h5 class="card-title">Product 1</h5>
-              <p class="card-text mb-4">&euro;10,00</p>
-              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="1" data-name="Product 1" data-price="10" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
-              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="1">Favoriet</button>
+              <h5 class="card-title"><?= htmlspecialchars($p['name']) ?></h5>
+              <p class="card-text mb-4">&euro;<?= number_format($p['price'], 2, ',', '.') ?></p>
+              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="<?= $p['id'] ?>" data-name="<?= htmlspecialchars($p['name']) ?>" data-price="<?= $p['price'] ?>" data-image="<?= htmlspecialchars($p['image_url']) ?>" data-variant="<?= htmlspecialchars($p['variant']) ?>">In winkelmand</button>
+              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="<?= $p['id'] ?>">Favoriet</button>
             </div>
           </div>
         </div>
-        <div class="col-md-6 mb-4 product-card" data-category="books">
-          <div class="card h-100">
-            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 2">
-            <div class="card-body d-flex flex-column">
-              <h5 class="card-title">Product 2</h5>
-              <p class="card-text mb-4">&euro;15,50</p>
-              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="2" data-name="Product 2" data-price="15.5" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
-              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="2">Favoriet</button>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-6 mb-4 product-card" data-category="home">
-          <div class="card h-100">
-            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 3">
-            <div class="card-body d-flex flex-column">
-              <h5 class="card-title">Product 3</h5>
-              <p class="card-text mb-4">&euro;7,25</p>
-              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="3" data-name="Product 3" data-price="7.25" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
-              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="3">Favoriet</button>
-            </div>
-          </div>
-        </div>
-        <div class="col-md-6 mb-4 product-card" data-category="electronics">
-          <div class="card h-100">
-            <img src="https://via.placeholder.com/300x200" class="card-img-top" alt="Product 4">
-            <div class="card-body d-flex flex-column">
-              <h5 class="card-title">Product 4</h5>
-              <p class="card-text mb-4">&euro;22,00</p>
-              <button class="btn btn-primary btn-cart btn-interactive w-100 mb-2" data-id="4" data-name="Product 4" data-price="22" data-image="https://via.placeholder.com/300x200">In winkelmand</button>
-              <button class="btn btn-outline-secondary btn-fav btn-interactive w-100" data-id="4">Favoriet</button>
-            </div>
-          </div>
-        </div>
+        <?php endforeach; ?>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add migration script creating products, product_categories, and product_images tables
- implement admin products module with list/edit/delete pages
- load products and variants from new tables on front-end product page

## Testing
- `php -l cron/create_product_tables.php`
- `php -l admin/modules/products/index.php`
- `php -l admin/modules/products/list.php`
- `php -l admin/modules/products/edit.php`
- `php -l admin/modules/products/delete.php`
- `php -l modules/product_page.php`


------
https://chatgpt.com/codex/tasks/task_e_689db5d2e364832a965891c8c3195d1a