### PR TITLE
Add cart and checkout modules with order storage

### DIFF
--- a/cron/migrate_orders.php
+++ b/cron/migrate_orders.php
@@ -1,0 +1,34 @@
+<?php
+require_once __DIR__ . '/../system/database.php';
+
+$ordersSql = "CREATE TABLE IF NOT EXISTS orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  user_id INT NULL,
+  email VARCHAR(255) NOT NULL,
+  status VARCHAR(20) NOT NULL DEFAULT 'pending',
+  total_amount DECIMAL(10,2) NOT NULL DEFAULT 0,
+  billing_address TEXT,
+  shipping_address TEXT,
+  payment_id VARCHAR(50),
+  created_at DATETIME NOT NULL,
+  paid_at DATETIME NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+
+$orderItemsSql = "CREATE TABLE IF NOT EXISTS order_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT NOT NULL,
+  product_id INT NULL,
+  name VARCHAR(255),
+  price DECIMAL(10,2) NOT NULL DEFAULT 0,
+  quantity INT NOT NULL DEFAULT 1,
+  FOREIGN KEY (order_id) REFERENCES orders(id)
+    ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;";
+
+try {
+    $pdo->exec($ordersSql);
+    $pdo->exec($orderItemsSql);
+    echo "Migratie voltooid\n";
+} catch (PDOException $e) {
+    echo "Fout: " . $e->getMessage() . "\n";
+}

--- a/modules/cart.php
+++ b/modules/cart.php
@@ -1,0 +1,22 @@
+<section class="mt-5">
+  <div class="container py-5">
+    <h1 class="mb-4">Winkelwagen</h1>
+    <table class="table" id="cartTable">
+      <thead>
+        <tr>
+          <th>Product</th>
+          <th style="width:150px">Aantal</th>
+          <th>Prijs</th>
+          <th>Totaal</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        <!-- Rijen worden dynamisch toegevoegd -->
+      </tbody>
+    </table>
+    <div class="text-end fw-bold">Grand Total: <span id="grandTotal">€0,00</span></div>
+    <div class="text-end mt-4"><a href="/modules/checkout.php" class="btn btn-primary">Afrekenen</a></div>
+  </div>
+</section>
+<script src="/js/cart.js"></script>

--- a/modules/checkout.php
+++ b/modules/checkout.php
@@ -1,0 +1,152 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Mollie\Api\MollieApiClient;
+
+$mollie = new MollieApiClient();
+$mollie->setApiKey('test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+$userId = $_SESSION['user_id'] ?? null;
+$errors = [];
+$message = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['action'] ?? '') === 'create_payment') {
+    $email = trim($_POST['email'] ?? '');
+    $cartJson = $_POST['cartData'] ?? '[]';
+    $cart = json_decode($cartJson, true) ?: [];
+
+    if (!$email) {
+        $errors[] = 'E-mail is verplicht';
+    }
+    if (!$cart) {
+        $errors[] = 'Winkelwagen is leeg';
+    }
+
+    if (!$errors) {
+        $billing = [
+            'street' => trim($_POST['billing_street'] ?? ''),
+            'postal_code' => trim($_POST['billing_postal'] ?? ''),
+            'city' => trim($_POST['billing_city'] ?? ''),
+            'country' => trim($_POST['billing_country'] ?? ''),
+        ];
+        $shipping = [
+            'street' => trim($_POST['shipping_street'] ?? ''),
+            'postal_code' => trim($_POST['shipping_postal'] ?? ''),
+            'city' => trim($_POST['shipping_city'] ?? ''),
+            'country' => trim($_POST['shipping_country'] ?? ''),
+        ];
+
+        $total = 0;
+        foreach ($cart as $item) {
+            $total += $item['price'] * $item['quantity'];
+        }
+        try {
+            $pdo->beginTransaction();
+            $stmt = $pdo->prepare("INSERT INTO orders (user_id,email,status,total_amount,billing_address,shipping_address,created_at) VALUES (?,?,?,?,?,?,NOW())");
+            $stmt->execute([
+                $userId,
+                $email,
+                'pending',
+                $total,
+                json_encode($billing),
+                json_encode($shipping)
+            ]);
+            $orderId = $pdo->lastInsertId();
+            $itemStmt = $pdo->prepare("INSERT INTO order_items (order_id,product_id,name,price,quantity) VALUES (?,?,?,?,?)");
+            foreach ($cart as $item) {
+                $itemStmt->execute([
+                    $orderId,
+                    $item['id'] ?? null,
+                    $item['name'] ?? '',
+                    $item['price'] ?? 0,
+                    $item['quantity'] ?? 1
+                ]);
+            }
+            $payment = $mollie->payments->create([
+                'amount' => [
+                    'currency' => 'EUR',
+                    'value' => number_format($total, 2, '.', ''),
+                ],
+                'description' => 'Order #' . $orderId,
+                'redirectUrl' => sprintf('https://%s/modules/success.php?order_id=%s', $_SERVER['HTTP_HOST'], $orderId),
+                'webhookUrl' => sprintf('https://%s/mollie_webhook.php', $_SERVER['HTTP_HOST']),
+                'metadata' => [
+                    'order_id' => $orderId,
+                    'user_id' => $userId,
+                ],
+            ]);
+            $pdo->prepare("UPDATE orders SET payment_id=? WHERE id=?")->execute([$payment->id, $orderId]);
+            $pdo->commit();
+            $_SESSION['order_id'] = $orderId;
+            header('Location: ' . $payment->getCheckoutUrl());
+            exit;
+        } catch (\Exception $e) {
+            $pdo->rollBack();
+            $errors[] = $e->getMessage();
+        }
+    }
+}
+?>
+<section class="mt-5">
+  <div class="container">
+    <h1>Checkout</h1>
+    <?php if ($errors): ?>
+    <div class="alert alert-danger">
+      <ul>
+        <?php foreach ($errors as $error): ?>
+        <li><?php echo htmlspecialchars($error); ?></li>
+        <?php endforeach; ?>
+      </ul>
+    </div>
+    <?php endif; ?>
+    <form method="post" id="checkoutForm">
+      <input type="hidden" name="action" value="create_payment">
+      <input type="hidden" name="cartData" id="cartData">
+      <div class="mb-3">
+        <label>E-mail</label>
+        <input type="email" name="email" class="form-control" required>
+      </div>
+      <h2>Factuuradres</h2>
+      <div class="mb-3">
+        <label>Straat</label>
+        <input type="text" name="billing_street" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label>Postcode</label>
+        <input type="text" name="billing_postal" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label>Stad</label>
+        <input type="text" name="billing_city" class="form-control" required>
+      </div>
+      <div class="mb-3">
+        <label>Land</label>
+        <input type="text" name="billing_country" class="form-control" required>
+      </div>
+      <h2>Afleveradres</h2>
+      <div class="mb-3">
+        <label>Straat</label>
+        <input type="text" name="shipping_street" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label>Postcode</label>
+        <input type="text" name="shipping_postal" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label>Stad</label>
+        <input type="text" name="shipping_city" class="form-control">
+      </div>
+      <div class="mb-3">
+        <label>Land</label>
+        <input type="text" name="shipping_country" class="form-control">
+      </div>
+      <button type="submit" class="btn btn-primary">Betaal</button>
+    </form>
+  </div>
+</section>
+<script>
+  document.getElementById('checkoutForm').addEventListener('submit', function(){
+    document.getElementById('cartData').value = localStorage.getItem('cart') || '[]';
+  });
+</script>

--- a/modules/success.php
+++ b/modules/success.php
@@ -1,0 +1,47 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../vendor/autoload.php';
+
+use Mollie\Api\MollieApiClient;
+
+$mollie = new MollieApiClient();
+$mollie->setApiKey('test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx');
+
+$orderId = $_GET['order_id'] ?? ($_SESSION['order_id'] ?? null);
+$order = null;
+$status = 'onbekend';
+
+if ($orderId) {
+    $stmt = $pdo->prepare('SELECT * FROM orders WHERE id = ?');
+    $stmt->execute([$orderId]);
+    $order = $stmt->fetch();
+    if ($order) {
+        $status = $order['status'];
+        if ($status !== 'betaald' && !empty($order['payment_id'])) {
+            try {
+                $payment = $mollie->payments->get($order['payment_id']);
+                if ($payment->isPaid()) {
+                    $pdo->prepare("UPDATE orders SET status='betaald', paid_at=NOW() WHERE id=?")->execute([$orderId]);
+                    $status = 'betaald';
+                }
+            } catch (Exception $e) {
+                $status = $order['status'];
+            }
+        }
+    }
+}
+?>
+<section class="mt-5">
+  <div class="container">
+    <?php if ($status === 'betaald'): ?>
+      <h1>Bedankt voor uw bestelling!</h1>
+      <p>Uw betaling is ontvangen.</p>
+    <?php else: ?>
+      <h1>Betaling in behandeling</h1>
+      <p>De status van uw bestelling is: <?php echo htmlspecialchars($status); ?></p>
+    <?php endif; ?>
+  </div>
+</section>
+<script>
+  localStorage.removeItem('cart');
+</script>


### PR DESCRIPTION
## Summary
- Add cart, checkout and success modules for a basic shop flow
- Persist orders and order items and integrate Mollie payments
- Mark paid orders via webhook and provide migration script for tables

## Testing
- `php -l modules/cart.php`
- `php -l modules/checkout.php`
- `php -l modules/success.php`
- `php -l mollie_webhook.php`
- `php -l cron/migrate_orders.php`


------
https://chatgpt.com/codex/tasks/task_e_689db5cf4a30832aa6f0582d94ba9ce0