### PR TITLE
Add order management scripts and shipping API service

### DIFF
--- a/admin/modules/orders/bin/detail.php
+++ b/admin/modules/orders/bin/detail.php
@@ -1,0 +1,24 @@
+<?php
+$path = $_SERVER['DOCUMENT_ROOT'];
+if (!isset($db)) {
+    require_once($path . "/system/database.php");
+    require_once($path . "/admin/src/database.class.php");
+    $db = new database($pdo);
+}
+require_once($path . "/admin/modules/orders/src/orders.class.php");
+
+$orders = new orders($pdo);
+$id = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$order = $orders->getOrder($id);
+if (!$order) {
+    echo "<p>Bestelling niet gevonden</p>";
+    exit;
+}
+?>
+<h3>Order #<?php echo $order['id']; ?></h3>
+<ul>
+  <li>Klant: <?php echo htmlspecialchars($order['customer_name']); ?></li>
+  <li>Status: <?php echo htmlspecialchars($order['status']); ?></li>
+  <li>Totaal: <?php echo htmlspecialchars($order['total']); ?></li>
+  <li>Factuur: <a href="<?php echo $order['invoice_pdf']; ?>" target="_blank">Download</a></li>
+</ul>

--- a/admin/modules/orders/bin/list.php
+++ b/admin/modules/orders/bin/list.php
@@ -39,7 +39,7 @@ $totalPages = $perPage > 0 ? ceil($total / $perPage) : 1;
         </select>
       </td>
       <td><a href="<?php echo $order['invoice_pdf']; ?>" target="_blank">Download</a></td>
-      <td></td>
+      <td><a href="/admin/modules/orders/bin/detail.php?id=<?php echo $order['id']; ?>" class="btn btn-sm btn-primary">Bekijken</a></td>
     </tr>
   <?php } ?>
   </tbody>

--- a/admin/modules/orders/js/orders.js
+++ b/admin/modules/orders/js/orders.js
@@ -1,6 +1,6 @@
 $(function(){
     function load(page){
-        $("#orderlist").load("/admin/modules/orders/bin/summary.php?page="+page);
+        $("#orderlist").load("/admin/modules/orders/bin/list.php?page="+page);
     }
     load(1);
 

--- a/admin/modules/orders/src/orders.class.php
+++ b/admin/modules/orders/src/orders.class.php
@@ -14,6 +14,13 @@ class orders {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public function getOrder($id) {
+        $sql = "SELECT * FROM orders WHERE id = :id LIMIT 1";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
     public function countOrders() {
         $sql = "SELECT COUNT(*) as cnt FROM orders";
         $stmt = $this->pdo->query($sql);

--- a/src/shipping.class.php
+++ b/src/shipping.class.php
@@ -1,0 +1,26 @@
+<?php
+class shipping {
+    private $apiKey;
+
+    public function __construct($apiKey) {
+        $this->apiKey = $apiKey;
+    }
+
+    public function getPostNLStatus($trackingNumber) {
+        $url = "https://api.postnl.nl/shipment/v2/status/" . urlencode($trackingNumber);
+        $ch = curl_init($url);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            "apikey: {$this->apiKey}",
+            "Accept: application/json"
+        ]);
+        $result = curl_exec($ch);
+        if ($result === false) {
+            curl_close($ch);
+            return false;
+        }
+        curl_close($ch);
+        return json_decode($result, true);
+    }
+}
+?>

--- a/src/site.class.php
+++ b/src/site.class.php
@@ -348,8 +348,29 @@ class site {
         }
         return $text;
     }
-    
-    
+
+
+    public function getOrdersByUser($userId) {
+        $sql = "SELECT * FROM orders WHERE user_id = :uid ORDER BY created_at DESC";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['uid' => $userId]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function getOrder($id) {
+        $sql = "SELECT * FROM orders WHERE id = :id LIMIT 1";
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute(['id' => $id]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function updateOrderStatus($id, $status) {
+        $sql = "UPDATE orders SET status = :status WHERE id = :id";
+        $stmt = $this->pdo->prepare($sql);
+        return $stmt->execute(['status' => $status, 'id' => $id]);
+    }
+
+   
    public function getUserByHash($hash)
 {
     try {


### PR DESCRIPTION
## Summary
- add paginated order list with detail links and status controls
- introduce order detail view and service class for PostNL shipping lookups
- extend site and admin order classes with order retrieval and mutation helpers

## Testing
- `php -l admin/modules/orders/bin/list.php`
- `php -l admin/modules/orders/bin/detail.php`
- `php -l admin/modules/orders/src/orders.class.php`
- `php -l src/site.class.php`
- `php -l src/shipping.class.php`
- `node --check admin/modules/orders/js/orders.js`


------
https://chatgpt.com/codex/tasks/task_e_689db5ce7ecc832a9614636e2b08895d