### PR TITLE
Add user address support and account pages

### DIFF
--- a/migrations/001_create_user_addresses.sql
+++ b/migrations/001_create_user_addresses.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS user_addresses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    type ENUM('billing','shipping') NOT NULL,
+    company_name VARCHAR(255) DEFAULT NULL,
+    kvk_number VARCHAR(255) DEFAULT NULL,
+    vat_number VARCHAR(255) DEFAULT NULL,
+    phone_number VARCHAR(50) DEFAULT NULL,
+    street VARCHAR(255) DEFAULT NULL,
+    postal_code VARCHAR(20) DEFAULT NULL,
+    city VARCHAR(100) DEFAULT NULL,
+    country VARCHAR(100) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY unique_user_type (user_id, type),
+    CONSTRAINT fk_user_addresses_user FOREIGN KEY (user_id) REFERENCES site_users(id) ON DELETE CASCADE
+);

--- a/migrations/002_migrate_existing_addresses.sql
+++ b/migrations/002_migrate_existing_addresses.sql
@@ -1,0 +1,2 @@
+INSERT INTO user_addresses (user_id, type, company_name, kvk_number, vat_number, phone_number, street, postal_code, city, country)
+SELECT userid, 'billing', company_name, kvk_number, vat_number, phone_number, street, postal_code, city, country FROM site_users_address;

--- a/modules/login.php
+++ b/modules/login.php
@@ -6,48 +6,30 @@ if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] == true) {
 
 <section class="mt-5">
     <div class="container mt-5">
-    <div class="row">
-      <div class="col-md-6">
-        <div class="card">
-          <div class="card-body">
-            <h3 class="card-title">Registratie</h3>
-            <div id="registrationMessage"></div>
-            <form id="registrationForm" method="post">
-              <div class="mb-3">
-                <label for="email" class="form-label">E-mailadres</label>
-                <input type="email" class="form-control" id="email" name="email" required>
-              </div>
-              <div class="mb-3">
-                <label for="password" class="form-label">Wachtwoord</label>
-                <input type="password" class="form-control" id="password" name="password" required>
-              </div>
-              <button type="submit" class="btn btn-primary">Registreren</button>
-            </form>
-          </div>
+        <div class="row">
+            <div class="col-md-6 mx-auto">
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="card-title">Inloggen</h3>
+                        <div id="loginMessage"></div>
+                        <form id="loginForm" method="post">
+                            <div class="mb-3">
+                                <label for="loginEmail" class="form-label">E-mailadres</label>
+                                <input type="email" class="form-control" id="loginEmail" name="loginEmail" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="loginPassword" class="form-label">Wachtwoord</label>
+                                <input type="password" class="form-control" id="loginPassword" name="loginPassword" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Inloggen</button>
+                        </form>
+                        <p class="mt-3">Nog geen account? <a href="/register.php">Registreer</a></p>
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-      <div class="col-md-6">
-        <div class="card">
-          <div class="card-body">
-            <h3 class="card-title">Inloggen</h3>
-              <div id="loginMessage"></div>
-            <form id="loginForm" method="post">
-              <div class="mb-3">
-                <label for="loginEmail" class="form-label">E-mailadres</label>
-                <input type="email" class="form-control" id="loginEmail" name="loginEmail" required>
-              </div>
-              <div class="mb-3">
-                <label for="loginPassword" class="form-label">Wachtwoord</label>
-                <input type="password" class="form-control" id="loginPassword" name="loginPassword" required>
-              </div>
-              <button type="submit" class="btn btn-primary">Inloggen</button>
-            </form>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
 </section>
 <script src="/js/login.js"></script>
-<script src="/js/registration.js"></script>
-<?php } ?>
+<?php }
+?>

--- a/modules/orders.php
+++ b/modules/orders.php
@@ -1,0 +1,28 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header("Location: /login.php");
+    exit();
+}
+require_once($_SERVER['DOCUMENT_ROOT'] . "/system/database.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "/src/database.class.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "/src/users.class.php");
+$users = new users($pdo);
+$userId = $users->getUserIdByHash($_SESSION['session_hash']);
+$orders = $users->getUserWonAuctions($userId);
+?>
+<section class="mt-5">
+    <div class="container mt-5">
+        <h3>Bestellingen</h3>
+        <?php if (!empty($orders)): ?>
+        <ul>
+            <?php foreach ($orders as $order): ?>
+            <li><?= htmlspecialchars($order['title'] ?? '') ?></li>
+            <?php endforeach; ?>
+        </ul>
+        <?php else: ?>
+        <p>Geen bestellingen gevonden.</p>
+        <?php endif; ?>
+    </div>
+</section>
+?>

--- a/modules/profile.php
+++ b/modules/profile.php
@@ -1,0 +1,25 @@
+<?php
+session_start();
+if (!isset($_SESSION['loggedin']) || $_SESSION['loggedin'] !== true) {
+    header("Location: /login.php");
+    exit();
+}
+require_once($_SERVER['DOCUMENT_ROOT'] . "/system/database.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "/src/database.class.php");
+require_once($_SERVER['DOCUMENT_ROOT'] . "/src/users.class.php");
+$users = new users($pdo);
+$userData = $users->getUserDataByUserId($_SESSION['session_hash']);
+?>
+<section class="mt-5">
+    <div class="container mt-5">
+        <h3>Profiel</h3>
+        <p>E-mailadres: <?= htmlspecialchars($userData['email'] ?? '') ?></p>
+        <h4 class="mt-4">Factuuradres</h4>
+        <p><?= htmlspecialchars($userData['street'] ?? '') ?>, <?= htmlspecialchars($userData['postal_code'] ?? '') ?> <?= htmlspecialchars($userData['city'] ?? '') ?></p>
+        <?php if (!empty($userData['shipping_street'])): ?>
+        <h4 class="mt-4">Verzendadres</h4>
+        <p><?= htmlspecialchars($userData['shipping_street']) ?>, <?= htmlspecialchars($userData['shipping_postal_code']) ?> <?= htmlspecialchars($userData['shipping_city']) ?></p>
+        <?php endif; ?>
+    </div>
+</section>
+?>

--- a/modules/register.php
+++ b/modules/register.php
@@ -1,0 +1,34 @@
+<?php
+if (isset($_SESSION['loggedin']) && $_SESSION['loggedin'] == true) {
+    header("Location: /users/index.php");
+    exit();
+}
+?>
+<section class="mt-5">
+    <div class="container mt-5">
+        <div class="row">
+            <div class="col-md-6 mx-auto">
+                <div class="card">
+                    <div class="card-body">
+                        <h3 class="card-title">Registratie</h3>
+                        <div id="registrationMessage"></div>
+                        <form id="registrationForm" method="post">
+                            <div class="mb-3">
+                                <label for="email" class="form-label">E-mailadres</label>
+                                <input type="email" class="form-control" id="email" name="email" required>
+                            </div>
+                            <div class="mb-3">
+                                <label for="password" class="form-label">Wachtwoord</label>
+                                <input type="password" class="form-control" id="password" name="password" required>
+                            </div>
+                            <button type="submit" class="btn btn-primary">Registreren</button>
+                        </form>
+                        <p class="mt-3">Al een account? <a href="/login.php">Inloggen</a></p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</section>
+<script src="/js/registration.js"></script>
+?>

--- a/orders.php
+++ b/orders.php
@@ -1,0 +1,39 @@
+<?php require_once("config.php"); ?>
+<!DOCTYPE html>
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title><?php echo $title; ?> | bestellingen</title>
+  <meta content="<?php echo $meta_description; ?>" name="description">
+  <meta content="<?php echo $meta_keywords; ?>" name="keywords">
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js" integrity="sha384-qlmct0AOBiA2VPZkMY3+2WqkHtIQ9lSdAsAn5RUJD/3vA5MKDgSGcdmIv4ycVxyn" crossorigin="anonymous"></script>
+
+  <!-- Favicons -- >
+  <link href="themes/onepage/assets/img/favicon.png" rel="icon">
+  <link href="themes/onepage/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Dosis:300,400,500,,600,700,700i|Lato:300,300i,400,400i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!--- Template Main CSS File -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/style.css" rel="stylesheet">
+
+</head>
+
+<body>
+<div id="display" class="alert-fixed"></div>
+<?php
+require_once($theme."/sections/header.php");
+require_once($_SERVER['DOCUMENT_ROOT']."/modules/orders.php");
+require_once($theme."/sections/footer.php");
+?>

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,39 @@
+<?php require_once("config.php"); ?>
+<!DOCTYPE html>
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title><?php echo $title; ?> | profiel</title>
+  <meta content="<?php echo $meta_description; ?>" name="description">
+  <meta content="<?php echo $meta_keywords; ?>" name="keywords">
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js" integrity="sha384-qlmct0AOBiA2VPZkMY3+2WqkHtIQ9lSdAsAn5RUJD/3vA5MKDgSGcdmIv4ycVxyn" crossorigin="anonymous"></script>
+
+  <!-- Favicons -- >
+  <link href="themes/onepage/assets/img/favicon.png" rel="icon">
+  <link href="themes/onepage/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Dosis:300,400,500,,600,700,700i|Lato:300,300i,400,400i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!--- Template Main CSS File -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/style.css" rel="stylesheet">
+
+</head>
+
+<body>
+<div id="display" class="alert-fixed"></div>
+<?php
+require_once($theme."/sections/header.php");
+require_once($_SERVER['DOCUMENT_ROOT']."/modules/profile.php");
+require_once($theme."/sections/footer.php");
+?>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,39 @@
+<?php require_once("config.php"); ?>
+<!DOCTYPE html>
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+
+  <title><?php echo $title; ?> | registreren</title>
+  <meta content="<?php echo $meta_description; ?>" name="description">
+  <meta content="<?php echo $meta_keywords; ?>" name="keywords">
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js" integrity="sha384-qlmct0AOBiA2VPZkMY3+2WqkHtIQ9lSdAsAn5RUJD/3vA5MKDgSGcdmIv4ycVxyn" crossorigin="anonymous"></script>
+
+  <!-- Favicons -- >
+  <link href="themes/onepage/assets/img/favicon.png" rel="icon">
+  <link href="themes/onepage/assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+
+  <!-- Google Fonts -->
+  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Dosis:300,400,500,,600,700,700i|Lato:300,300i,400,400i,700,700i" rel="stylesheet">
+
+  <!-- Vendor CSS Files -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+
+  <!--- Template Main CSS File -->
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/style.css" rel="stylesheet">
+
+</head>
+
+<body>
+<div id="display" class="alert-fixed"></div>
+<?php
+require_once($theme."/sections/header.php");
+require_once($_SERVER['DOCUMENT_ROOT']."/modules/register.php");
+require_once($theme."/sections/footer.php");
+?>


### PR DESCRIPTION
## Summary
- store billing and shipping details in new `user_addresses` table and expose through `users.class.php`
- split login into account modules for registering, profile view and order history
- add SQL migrations to create and populate the `user_addresses` table

## Testing
- `php -l src/users.class.php modules/login.php modules/register.php modules/profile.php modules/orders.php register.php profile.php orders.php`

------
https://chatgpt.com/codex/tasks/task_e_689db5cd7774832a8cfaa4a54dc80fac