### PR TITLE
Add meta data and publishing controls for pages

### DIFF
--- a/admin/modules/content/bin/activate.php
+++ b/admin/modules/content/bin/activate.php
@@ -19,8 +19,8 @@ $error = '<div class="alert alert-danger" role="alert">Er is iets fout gegaan!</
 
 if(isset($_POST['id'])) {
 
- $hash = $_POST['id'];
- $status = $_POST['status'];
+$hash = $_POST['id'];
+$status = ($_POST['status'] === 'published') ? 'published' : 'draft';
 	
  $sql = "UPDATE group_content SET status=:status WHERE hash=:hash";
  $go = $db->runQuery($sql, ['status'=>$status, 'hash'=>$hash]);

--- a/admin/modules/content/bin/add.php
+++ b/admin/modules/content/bin/add.php
@@ -61,15 +61,18 @@ if ( $_SERVER[ 'REQUEST_METHOD' ] == 'POST' ) {
 	
   if ($pass == 0 ) { 
  
-	  $values = array(
-		  'hash' => $hash
-		  , 'group_id' => $group_id
-		  , 'title' => $title
-		  , 'content' => $article
-		  , 'location' => $location
-		  , 'seo_url' => $seo_url
-		  , 'keywords' => $keywords
-	  );
+          $values = array(
+                  'hash' => $hash
+                  , 'group_id' => $group_id
+                  , 'title' => $title
+                  , 'content' => $article
+                  , 'location' => $location
+                  , 'seo_url' => $seo_url
+                  , 'keywords' => $keywords
+                  , 'meta_title' => ''
+                  , 'meta_description' => ''
+                  , 'status' => 'draft'
+          );
 	  $go = $db->insertdata("group_content", $values);
 	  
 	  if($go == true) {

--- a/admin/modules/content/bin/summary.php
+++ b/admin/modules/content/bin/summary.php
@@ -19,7 +19,7 @@ if ( isset( $_SESSION[ 'group_id' ] ) ) {
         <div class="col">
         
             <div class="form-check-inline form-switch mt-2">
-                <input class="form-check-input switchbox" type="checkbox" data-set="<?php echo $data['hash']; ?>" <?php echo ($data['status'] == 'y') ? 'checked' : ''; ?>>
+                <input class="form-check-input switchbox" type="checkbox" data-set="<?php echo $data['hash']; ?>" <?php echo ($data['status'] == 'published') ? 'checked' : ''; ?>>
             </div>
 
             

--- a/admin/modules/content/edit.php
+++ b/admin/modules/content/edit.php
@@ -1,6 +1,7 @@
 <?php
-require_once("src/content.class.php"); 
-require_once("../admin/src/menulist.class.php"); 
+require_once __DIR__ . '/src/content.class.php';
+require_once __DIR__ . '/../../src/menulist.class.php';
+require_once __DIR__ . '/../../summernote.php';
 
 // Get ID from URL rewriting or GET parameters
 $id = $_GET['id'] ?? 0;
@@ -37,6 +38,8 @@ if ($result && is_array($result)) {
 		$keywords 	= $row['keywords'];
 		$sortnum 	= $row['sortnum'];
 		$status 	= $row['status'];
+		$meta_title 	= $row['meta_title'];
+		$meta_description = $row['meta_description'];
 
 		$selectbox = selectbox("Kies menu item", 'location', $location, array_combine($MenuLocations, $MenuNames), 'class="form-select autosave" data-field="location" data-set="'.$hash.'"');
     }

--- a/admin/modules/content/forms/edit.php
+++ b/admin/modules/content/forms/edit.php
@@ -7,24 +7,36 @@
 			  <label for="menuLabel">Titel</label>
 				<?php echo input("text", 'title[]', $title, "title".$id, 'class="form-control autosave" data-field="title" data-set="'.$hash.'"'); ?>
 			</div>
-			<div class="form-group mt-2 mb-2">
+                        <div class="form-group mt-2 mb-2">
                 <label for="location">Artikel</label>
-				<?php 
-				$extra = 'class="form-control autosave wysiwyg" data-field="content" data-set="'.$hash.'"';
-				echo textarea('content', $content, $extra); 
-				?>
-			  </div>
-				  <?php echo $selectbox; ?>
-			  <div class="form-group mt-2">
-			  <label for="location">SEO Url</label>
-				  <?php echo input("text", 'seo_url[]', $seo_url, "seo_url".$id, 'class="form-control autosave" data-field="seo_url" data-set="'.$hash.'"'); ?>
-				  <small>* optioneel - wordt automatisch gegenereerd bij eerste invoer</small>
-			  </div>
-			<div class="form-group mt-2">
-			  <label for="location">Zoekwoorden</label>
-				  <?php echo input("text", 'keywords[]', $keywords, "keywords".$id, 'class="form-control autosave" data-field="keywords" data-set="'.$hash.'"'); ?>
-			 	  <small>* optioneel - komma gescheiden</small>
-			  </div>
+                                <?php
+                                $extra = 'class="form-control autosave wysiwyg" data-field="content" data-set="'.$hash.'"';
+                                summernote_editor('content', $content, $extra);
+                                ?>
+                          </div>
+                                  <?php echo $selectbox; ?>
+                          <div class="form-group mt-2">
+                          <label for="location">SEO Url</label>
+                                  <?php echo input("text", 'seo_url[]', $seo_url, "seo_url".$id, 'class="form-control autosave" data-field="seo_url" data-set="'.$hash.'"'); ?>
+                                  <small>* optioneel - wordt automatisch gegenereerd bij eerste invoer</small>
+                          </div>
+                        <div class="form-group mt-2">
+                          <label for="meta_title">Meta Title</label>
+                                  <?php echo input("text", 'meta_title[]', $meta_title, "meta_title".$id, 'class="form-control autosave" data-field="meta_title" data-set="'.$hash.'"'); ?>
+                        </div>
+                        <div class="form-group mt-2">
+                          <label for="meta_description">Meta Description</label>
+                                  <?php echo textarea('meta_description', $meta_description, 'class="form-control autosave" data-field="meta_description" data-set="'.$hash.'"'); ?>
+                        </div>
+                        <div class="form-group mt-2">
+                          <label for="status">Status</label>
+                                  <?php echo selectbox("Status", 'status', $status, ['draft'=>'Draft', 'published'=>'Published'], 'class="form-select autosave" data-field="status" data-set="'.$hash.'"'); ?>
+                        </div>
+                        <div class="form-group mt-2">
+                          <label for="location">Zoekwoorden</label>
+                                  <?php echo input("text", 'keywords[]', $keywords, "keywords".$id, 'class="form-control autosave" data-field="keywords" data-set="'.$hash.'"'); ?>
+                                  <small>* optioneel - komma gescheiden</small>
+                          </div>
 		
 		  </div>
 		  </div>

--- a/admin/modules/content/forms/edit_example.php
+++ b/admin/modules/content/forms/edit_example.php
@@ -91,8 +91,8 @@ if ($content_id) {
                                 <div class="form-group">
                                     <label for="status">Status:</label>
                                     <select name="status" id="status" class="form-control">
-                                        <option value="y" <?php echo $content['status'] == 'y' ? 'selected' : ''; ?>>Actief</option>
-                                        <option value="n" <?php echo $content['status'] == 'n' ? 'selected' : ''; ?>>Inactief</option>
+                                        <option value="draft" <?php echo $content['status'] == 'draft' ? 'selected' : ''; ?>>Draft</option>
+                                        <option value="published" <?php echo $content['status'] == 'published' ? 'selected' : ''; ?>>Published</option>
                                     </select>
                                 </div>
                                 

--- a/admin/modules/content/index.php
+++ b/admin/modules/content/index.php
@@ -38,7 +38,7 @@ $selectbox = selectbox("Kies menu item", 'location', '', array_combine($MenuLoca
             <div class="card-header">
             <div class="row">
   <div class="col-8"><h5>Titel</h5></div>
-  <div class="col-2"><h5>Aan/Uit</h5></div>
+  <div class="col-2"><h5>Status</h5></div>
   <div class="col-2 text-end"><h5>Acties</h5></div>
 </div>
             </div>

--- a/admin/modules/content/js/js.js
+++ b/admin/modules/content/js/js.js
@@ -133,7 +133,7 @@ Sortable.create(menuList, {
   $(".switchbox").on('click', (function () {
 
     var id = $(this).attr("data-set");
-    var status = $(this).is(":checked") ? 'y' : 'n';
+    var status = $(this).is(":checked") ? 'published' : 'draft';
 
     $.ajax({
       type: "post",

--- a/admin/modules/pages/edit.php
+++ b/admin/modules/pages/edit.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/../../summernote.php';
+$cwd = getcwd();
+chdir(__DIR__ . '/../content');
+require_once 'edit.php';
+chdir($cwd);
+?>

--- a/admin/modules/pages/index.php
+++ b/admin/modules/pages/index.php
@@ -1,0 +1,7 @@
+<?php
+// Wrapper module for page management reusing content module functionality.
+$cwd = getcwd();
+chdir(__DIR__ . '/../content');
+require_once 'index.php';
+chdir($cwd);
+?>

--- a/admin/summernote.php
+++ b/admin/summernote.php
@@ -1,94 +1,14 @@
 <?php
-session_start();
-$sessid = session_id();
-
-error_reporting( E_ALL ^ E_DEPRECATED );
-ini_set( "display_errors", 1 );
-
-include( "../system/database.php" );
-
-require_once( "src/database.class.php" );
-require_once( "src/menulist.class.php" );
-require_once( "functions/forms.php" );
-
-$db   	 = new database($pdo);
-$menu 	 = new menu($pdo);
+/**
+ * Helper function to render a Summernote editor field.
+ *
+ * @param string $name      Field name/id for the textarea.
+ * @param string $content   Initial HTML content for the editor.
+ * @param string $attributes Extra HTML attributes for the textarea.
+ */
+function summernote_editor(string $name, string $content = '', string $attributes = ''): void {
+    $attrs = $attributes ? ' ' . $attributes : '';
+    echo '<textarea id="' . htmlspecialchars($name, ENT_QUOTES) . '" name="' . htmlspecialchars($name, ENT_QUOTES) . '"' . $attrs . '>'
+        . htmlspecialchars($content) . '</textarea>';
+}
 ?>
-<!DOCTYPE html>
-<html lang="nl">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="description" content="">
-<meta name="author" content="">
-<meta name="keywords" content="">
-<meta name="revisit-after" content="7 days">
-<meta name="format-detection" content="telephone=no">
-<title>
-CMS
-</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-1BmE4kWBq78iYhFldvKuhfTAU6auU8tT94WrHftjDbrCEXSU1oBoqyl2QvZ6jIW3" crossorigin="anonymous">
-	
-	
-<script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
-
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-ka7Sk0Gln4gmtz2MlQnikT1wXgYsOg+OMhuP+IlRH9sENBO0LRn5q+8nbTov4+1p" crossorigin="anonymous"></script> 
-	
-
-<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery.form/4.3.0/jquery.form.min.js" integrity="sha384-qlmct0AOBiA2VPZkMY3+2WqkHtIQ9lSdAsAn5RUJD/3vA5MKDgSGcdmIv4ycVxyn" crossorigin="anonymous"></script>
-
-<!-- include summernote css/js -->
-<link href="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote-lite.min.css" rel="stylesheet">
-<script src="https://cdn.jsdelivr.net/npm/summernote@0.8.18/dist/summernote-lite.min.js"></script>
-
-<!-- drag and drop -->	
-<script src="https://cdn.jsdelivr.net/npm/sortablejs@latest/Sortable.min.js"></script> 
-
-<!-- Bootstrap core CSS -->
-<link href="css/main.css" rel="stylesheet">
-	
-<script src="/admin/js/global.js"></script>
-
-<script type="application/javascript">
-$( document ).ready( function () {
-	
-	  //$('#article').summernote();
-
-} );
-</script>
-<script>
-    $(document).ready(function() {
-        $("#your_summernote").summernote();
-        $('.dropdown-toggle').dropdown();
-    });
-	</script>
-	<style>
-
-	</style>
-</head>
-<body>
-    
-    <div class="container">
-        <div class="row">
-            <div class="col-md-12">
-                <div class="card">
-                    <div class="card-header">
-                        <h4>Integrate Summernote with Bootstrap 5 in PHP/HTML</h4>
-                    </div>
-                    <div class="card-body">
-
-                        <form action="#">
-                            <div class="mb-3">
-                                <label>Big Description</label>
-                                <textarea name="description" id="your_summernote" rows="4"></textarea>
-                            </div>
-                        </form>
-
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-</body>
-</html>

--- a/admin/template/navtabs.php
+++ b/admin/template/navtabs.php
@@ -16,6 +16,10 @@ $id 	= isset($_GET["id"]) ? $_GET['id'] : 0;
     <li class="nav-item" role="presentation">
       <a class="nav-link <?php echo ($module == 'content') ? "active" : ''; ?>" id="profile-tab" href="/admin/content/" role="tab" aria-controls="content" aria-selected="false">Content</a>
     </li>
+
+    <li class="nav-item" role="presentation">
+      <a class="nav-link <?php echo ($module == 'pages') ? "active" : ''; ?>" id="pages-tab" href="/admin/pages/" role="tab" aria-controls="pages" aria-selected="false">Paginas</a>
+    </li>
 	   
     <li class="nav-item" role="presentation">
       <a class="nav-link <?php echo ($module == 'keywords') ? "active" : ''; ?>" id="settings-tab" href="/admin/keywords/" role="tab" aria-controls="keywords" aria-selected="false">Zoekwoorden</a>
@@ -32,11 +36,13 @@ $id 	= isset($_GET["id"]) ? $_GET['id'] : 0;
 <?php 
 
 //print_r($_GET);
-if ($module == 'menu') { require_once("modules/menu/index.php"); } 
-//if ($module == 'content' && $action != 'edit') { require_once("modules/content/index.php"); } 
-if ($module == 'content' && $action == 'edit') { require_once("modules/content/edit.php"); } 
-if ($module == 'keywords') { require_once("modules/keywords/index.php"); } 
-if ($module == 'config') { require_once("modules/config/index.php"); } 
+if ($module == 'menu') { require_once("modules/menu/index.php"); }
+//if ($module == 'content' && $action != 'edit') { require_once("modules/content/index.php"); }
+if ($module == 'content' && $action == 'edit') { require_once("modules/content/edit.php"); }
+if ($module == 'pages' && $action == 'edit') { require_once("modules/pages/edit.php"); }
+if ($module == 'pages' && $action != 'edit') { require_once("modules/pages/index.php"); }
+if ($module == 'keywords') { require_once("modules/keywords/index.php"); }
+if ($module == 'config') { require_once("modules/config/index.php"); }
 ?>
 
 

--- a/src/site.class.php
+++ b/src/site.class.php
@@ -92,7 +92,7 @@ class site {
 			return "E01";
 		} else {
 
-			$sql = "SELECT COUNT(*) AS total FROM group_content WHERE location = :location AND status = 'y'";
+                        $sql = "SELECT COUNT(*) AS total FROM group_content WHERE location = :location AND status = 'published'";
 
 			$stmt = $this->pdo->prepare( $sql );
 			$stmt->execute( [ 'location' => $location ] );
@@ -128,7 +128,7 @@ class site {
 			return "E01";
 		} else {
 
-			$sql = "SELECT * FROM group_content WHERE group_id = :groupid AND location = :location AND status = 'y' ORDER BY sortnum ASC";
+                        $sql = "SELECT * FROM group_content WHERE group_id = :groupid AND location = :location AND status = 'published' ORDER BY sortnum ASC";
 
 			$stmt = $this->pdo->prepare( $sql );
 			$stmt->execute( [ 'groupid' => $groupid, 'location' => $location ] );
@@ -146,7 +146,7 @@ class site {
 			return "E01";
 		} else {
 
-			$sql = "SELECT * FROM group_content WHERE group_id = :groupid AND status = 'y' ORDER BY sortnum ASC";
+                        $sql = "SELECT * FROM group_content WHERE group_id = :groupid AND status = 'published' ORDER BY sortnum ASC";
 
 			$stmt = $this->pdo->prepare( $sql );
 			$stmt->execute( [ 'groupid' => $groupid ] );

--- a/update_group_content_table.php
+++ b/update_group_content_table.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Update script to extend group_content table with meta fields and status.
+ * Run via browser or CLI: /update_group_content_table.php
+ */
+
+error_reporting(E_ALL);
+ini_set('display_errors', 1);
+
+require_once 'system/database.php';
+require_once 'src/database.class.php';
+
+$db = new database($pdo);
+
+$success = [];
+$errors = [];
+
+try {
+    // meta_title
+    $stmt = $pdo->prepare("SHOW COLUMNS FROM group_content LIKE 'meta_title'");
+    $stmt->execute();
+    if ($stmt->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE group_content ADD COLUMN meta_title VARCHAR(255) DEFAULT NULL");
+        $success[] = "✅ Kolom meta_title toegevoegd";
+    } else {
+        $success[] = "ℹ️ Kolom meta_title bestaat al";
+    }
+
+    // meta_description
+    $stmt = $pdo->prepare("SHOW COLUMNS FROM group_content LIKE 'meta_description'");
+    $stmt->execute();
+    if ($stmt->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE group_content ADD COLUMN meta_description TEXT DEFAULT NULL");
+        $success[] = "✅ Kolom meta_description toegevoegd";
+    } else {
+        $success[] = "ℹ️ Kolom meta_description bestaat al";
+    }
+
+    // status column
+    $stmt = $pdo->prepare("SHOW COLUMNS FROM group_content LIKE 'status'");
+    $stmt->execute();
+    if ($stmt->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE group_content ADD COLUMN status ENUM('draft','published') NOT NULL DEFAULT 'draft'");
+        $success[] = "✅ Kolom status toegevoegd";
+    } else {
+        $pdo->exec("ALTER TABLE group_content MODIFY status ENUM('draft','published') NOT NULL DEFAULT 'draft'");
+        $success[] = "ℹ️ Kolom status bijgewerkt";
+    }
+} catch (Exception $e) {
+    $errors[] = $e->getMessage();
+}
+
+header('Content-Type: text/html; charset=utf-8');
+echo "<h1>Group content update</h1>";
+echo "<h3>Resultaten</h3><ul>";
+foreach ($success as $msg) {
+    echo "<li>{$msg}</li>";
+}
+echo "</ul>";
+if ($errors) {
+    echo "<h3>Fouten</h3><ul>";
+    foreach ($errors as $err) {
+        echo "<li>{$err}</li>";
+    }
+    echo "</ul>";
+}
+?>


### PR DESCRIPTION
## Summary
- add reusable `summernote_editor` helper and use it for page editing
- extend group_content with meta title/description and draft-published status
- introduce pages module with overview page and update script for new columns

## Testing
- `php -l admin/summernote.php`
- `php -l admin/modules/content/edit.php`
- `php -l admin/modules/content/forms/edit.php`
- `php -l admin/modules/content/bin/add.php`
- `php -l admin/modules/content/bin/activate.php`
- `php -l admin/modules/content/bin/summary.php`
- `php -l admin/modules/content/index.php`
- `php -l admin/modules/content/forms/edit_example.php`
- `php -l admin/modules/pages/index.php`
- `php -l admin/modules/pages/edit.php`
- `php -l admin/template/navtabs.php`
- `php -l src/site.class.php`
- `php -l update_group_content_table.php`


------
https://chatgpt.com/codex/tasks/task_e_689db5cb15e4832a9ccf4a40a9f9502c