### PR TITLE
Generate sitemap and add SEO metadata controls

### DIFF
--- a/admin/modules/content/edit.php
+++ b/admin/modules/content/edit.php
@@ -38,6 +38,13 @@ if ($result && is_array($result)) {
 		$sortnum 	= $row['sortnum'];
 		$status 	= $row['status'];
 
+                $meta_title     = $row['meta_title'] ?? '';
+                $meta_description = $row['meta_description'] ?? '';
+                $og_title       = $row['og_title'] ?? '';
+                $og_description = $row['og_description'] ?? '';
+                $og_image       = $row['og_image'] ?? '';
+
+
 		$selectbox = selectbox("Kies menu item", 'location', $location, array_combine($MenuLocations, $MenuNames), 'class="form-select autosave" data-field="location" data-set="'.$hash.'"');
     }
 } else {

--- a/admin/modules/content/forms/add.php
+++ b/admin/modules/content/forms/add.php
@@ -1,8 +1,6 @@
 <button type="button" class="pink-button" data-bs-toggle="modal" data-bs-target="#modal">+</button>
 <form action="/admin/modules/content/bin/add.php" enctype="multipart/form-data" method="post" name="menuform" id="menuform" autocomplete="off">
   <input type="hidden" id="content" name="content" value="Binnenkort meer...">
-  <input type="hidden" name="seo_url" class="form-control" id="seo_url" placeholder="seo url">
-  <input type="hidden" name="keywords" class="form-control" id="keywords" placeholder="Zoekwoorden">
   <input type="hidden" name="group_id" value="<?php echo $group_id; ?>">
   <input type="hidden" id="hash" name="hash" value="">
   <div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-hidden="true">
@@ -13,11 +11,54 @@
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-          <div class="form-group mb-4">
-            <label for="menuLabel">Titel</label>
-            <input type="text" name="title" class="form-control" id="menuLabel" aria-describedby="menuLabel" placeholder="Vul menu naam in" required>
+          <ul class="nav nav-tabs" id="addContentTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="add-content-general-tab" data-bs-toggle="tab" data-bs-target="#add-content-general" type="button" role="tab">Algemeen</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="add-content-seo-tab" data-bs-toggle="tab" data-bs-target="#add-content-seo" type="button" role="tab">SEO</button>
+            </li>
+          </ul>
+          <div class="tab-content pt-3" id="addContentTabContent">
+            <div class="tab-pane fade show active" id="add-content-general" role="tabpanel" aria-labelledby="add-content-general-tab">
+              <div class="form-group mb-4">
+                <label for="menuLabel">Titel</label>
+                <input type="text" name="title" class="form-control" id="menuLabel" aria-describedby="menuLabel" placeholder="Vul menu naam in" required>
+              </div>
+              <?php echo $selectbox; ?>
+            </div>
+            <div class="tab-pane fade" id="add-content-seo" role="tabpanel" aria-labelledby="add-content-seo-tab">
+              <div class="form-group mt-2">
+                <label for="seo_url">SEO Url</label>
+                <input type="text" name="seo_url" class="form-control" id="seo_url" placeholder="seo url">
+              </div>
+              <div class="form-group mt-2">
+                <label for="keywords">Zoekwoorden</label>
+                <input type="text" name="keywords" class="form-control" id="keywords" placeholder="Zoekwoorden">
+              </div>
+              <div class="form-group mt-2">
+                <label for="meta_title">Meta titel</label>
+                <input type="text" name="meta_title" class="form-control" id="meta_title">
+              </div>
+              <div class="form-group mt-2">
+                <label for="meta_description">Meta omschrijving</label>
+                <textarea name="meta_description" class="form-control" id="meta_description"></textarea>
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_title">OG titel</label>
+                <input type="text" name="og_title" class="form-control" id="og_title">
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_description">OG omschrijving</label>
+                <textarea name="og_description" class="form-control" id="og_description"></textarea>
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_image">OG afbeelding URL</label>
+                <input type="text" name="og_image" class="form-control" id="og_image">
+              </div>
+            </div>
           </div>
-          <?php echo $selectbox; ?> </div>
+        </div>
         <div class="modal-footer">
           <button class="btn btn-danger" data-bs-target="#modal" data-bs-toggle="modal" data-bs-dismiss="modal" >Annuleren</button>
           <button type="submit" data-bs-target="#modal" data-bs-toggle="modal" data-bs-dismiss="modal" class="btn btn-dark" id="add_menu_item">Toevoegen</button>

--- a/admin/modules/content/forms/edit.php
+++ b/admin/modules/content/forms/edit.php
@@ -1,31 +1,65 @@
-			<input type="hidden" name="group_id" value="<?php echo $group_id; ?>">
-			<input type="hidden" id="hash" name="hash" value="<?php echo $hash; ?>">
-		  <div class="card shadow">
-			  <h5 class="card-header">Bewerken</h5>
-			  <div class="card-body">
-			<div class="form-group mt-2">
-			  <label for="menuLabel">Titel</label>
-				<?php echo input("text", 'title[]', $title, "title".$id, 'class="form-control autosave" data-field="title" data-set="'.$hash.'"'); ?>
-			</div>
-			<div class="form-group mt-2 mb-2">
-                <label for="location">Artikel</label>
-				<?php 
-				$extra = 'class="form-control autosave wysiwyg" data-field="content" data-set="'.$hash.'"';
-				echo textarea('content', $content, $extra); 
-				?>
-			  </div>
-				  <?php echo $selectbox; ?>
-			  <div class="form-group mt-2">
-			  <label for="location">SEO Url</label>
-				  <?php echo input("text", 'seo_url[]', $seo_url, "seo_url".$id, 'class="form-control autosave" data-field="seo_url" data-set="'.$hash.'"'); ?>
-				  <small>* optioneel - wordt automatisch gegenereerd bij eerste invoer</small>
-			  </div>
-			<div class="form-group mt-2">
-			  <label for="location">Zoekwoorden</label>
-				  <?php echo input("text", 'keywords[]', $keywords, "keywords".$id, 'class="form-control autosave" data-field="keywords" data-set="'.$hash.'"'); ?>
-			 	  <small>* optioneel - komma gescheiden</small>
-			  </div>
-		
-		  </div>
-		  </div>
-		</form>
+<form method="post">
+<input type="hidden" name="group_id" value="<?php echo $group_id; ?>">
+<input type="hidden" id="hash" name="hash" value="<?php echo $hash; ?>">
+<div class="card shadow">
+  <h5 class="card-header">Bewerken</h5>
+  <div class="card-body">
+    <ul class="nav nav-tabs" id="contentTab" role="tablist">
+      <li class="nav-item" role="presentation">
+        <button class="nav-link active" id="content-general-tab" data-bs-toggle="tab" data-bs-target="#content-general" type="button" role="tab">Algemeen</button>
+      </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="content-seo-tab" data-bs-toggle="tab" data-bs-target="#content-seo" type="button" role="tab">SEO</button>
+      </li>
+    </ul>
+    <div class="tab-content pt-3" id="contentTabContent">
+      <div class="tab-pane fade show active" id="content-general" role="tabpanel" aria-labelledby="content-general-tab">
+        <div class="form-group mt-2">
+          <label for="menuLabel">Titel</label>
+          <?php echo input("text", 'title[]', $title, "title".$id, 'class="form-control autosave" data-field="title" data-set="'.$hash.'"'); ?>
+        </div>
+        <div class="form-group mt-2 mb-2">
+          <label for="location">Artikel</label>
+          <?php
+          $extra = 'class="form-control autosave wysiwyg" data-field="content" data-set="'.$hash.'"';
+          echo textarea('content', $content, $extra);
+          ?>
+        </div>
+        <?php echo $selectbox; ?>
+        <div class="form-group mt-2">
+          <label for="location">SEO Url</label>
+          <?php echo input("text", 'seo_url[]', $seo_url, "seo_url".$id, 'class="form-control autosave" data-field="seo_url" data-set="'.$hash.'"'); ?>
+          <small>* optioneel - wordt automatisch gegenereerd bij eerste invoer</small>
+        </div>
+        <div class="form-group mt-2">
+          <label for="location">Zoekwoorden</label>
+          <?php echo input("text", 'keywords[]', $keywords, "keywords".$id, 'class="form-control autosave" data-field="keywords" data-set="'.$hash.'"'); ?>
+          <small>* optioneel - komma gescheiden</small>
+        </div>
+      </div>
+      <div class="tab-pane fade" id="content-seo" role="tabpanel" aria-labelledby="content-seo-tab">
+        <div class="form-group mt-2">
+          <label for="meta_title">Meta titel</label>
+          <?php echo input("text", 'meta_title[]', $meta_title, "meta_title".$id, 'class="form-control autosave" data-field="meta_title" data-set="'.$hash.'"'); ?>
+        </div>
+        <div class="form-group mt-2">
+          <label for="meta_description">Meta omschrijving</label>
+          <?php echo textarea('meta_description', $meta_description, 'class="form-control autosave" data-field="meta_description" data-set="'.$hash.'"'); ?>
+        </div>
+        <div class="form-group mt-2">
+          <label for="og_title">OG titel</label>
+          <?php echo input("text", 'og_title[]', $og_title, "og_title".$id, 'class="form-control autosave" data-field="og_title" data-set="'.$hash.'"'); ?>
+        </div>
+        <div class="form-group mt-2">
+          <label for="og_description">OG omschrijving</label>
+          <?php echo textarea('og_description', $og_description, 'class="form-control autosave" data-field="og_description" data-set="'.$hash.'"'); ?>
+        </div>
+        <div class="form-group mt-2">
+          <label for="og_image">OG afbeelding URL</label>
+          <?php echo input("text", 'og_image[]', $og_image, "og_image".$id, 'class="form-control autosave" data-field="og_image" data-set="'.$hash.'"'); ?>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</form>

--- a/admin/modules/products/edit.php
+++ b/admin/modules/products/edit.php
@@ -30,6 +30,11 @@ $description   = $row['description'];
 $category      = $row['category'];
 $stock         = $row['stock'];
 $btw         = $row['btw'];
+$meta_title      = $row['meta_title'] ?? '';
+$meta_description = $row['meta_description'] ?? '';
+$og_title        = $row['og_title'] ?? '';
+$og_description  = $row['og_description'] ?? '';
+$og_image        = $row['og_image'] ?? '';
 }
 
 $img = $products->getImageName($id );

--- a/admin/modules/products/forms/add.php
+++ b/admin/modules/products/forms/add.php
@@ -4,8 +4,7 @@
 
 <input type="hidden" name="group_id" value="<?php echo $group_id; ?>">
 <input type="hidden" id="hash" name="hash" value="">
- 
-    
+
 <div class="modal fade" id="modal" tabindex="-1" role="dialog" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-lg">
       <div class="modal-content">
@@ -14,19 +13,50 @@
           <button type="button" class="btn-close btn-close-white" data-bs-dismiss="modal" aria-label="Close"></button>
         </div>
         <div class="modal-body">
-        
-          <div class="row">
-            <div class="form-group mt-2 col-md-6">
-              <label for="title">Productnaam</label>
-              <input type="text" name="title" class="form-control" id="menuLabel" aria-describedby="menuLabel" placeholder="Productnaam" required>
+          <ul class="nav nav-tabs" id="addProductTab" role="tablist">
+            <li class="nav-item" role="presentation">
+              <button class="nav-link active" id="add-general-tab" data-bs-toggle="tab" data-bs-target="#add-general" type="button" role="tab">Algemeen</button>
+            </li>
+            <li class="nav-item" role="presentation">
+              <button class="nav-link" id="add-seo-tab" data-bs-toggle="tab" data-bs-target="#add-seo" type="button" role="tab">SEO</button>
+            </li>
+          </ul>
+          <div class="tab-content pt-3" id="addProductTabContent">
+            <div class="tab-pane fade show active" id="add-general" role="tabpanel" aria-labelledby="add-general-tab">
+              <div class="row">
+                <div class="form-group mt-2 col-md-6">
+                  <label for="title">Productnaam</label>
+                  <input type="text" name="title" class="form-control" id="menuLabel" aria-describedby="menuLabel" placeholder="Productnaam" required>
+                </div>
+                <div class="form-group mt-2 col-md-6">
+                  <label for="category">Categorie</label>
+                  <input type="text" name="category" class="form-control" id="category" placeholder="Categorie" required>
+                </div>
+              </div>
             </div>
-            <div class="form-group mt-2 col-md-6">
-              <label for="category">Categorie</label>
-              <input type="text" name="category" class="form-control" id="category" placeholder="Categorie" required>
+            <div class="tab-pane fade" id="add-seo" role="tabpanel" aria-labelledby="add-seo-tab">
+              <div class="form-group mt-2">
+                <label for="meta_title">Meta titel</label>
+                <input type="text" name="meta_title" class="form-control" id="meta_title">
+              </div>
+              <div class="form-group mt-2">
+                <label for="meta_description">Meta omschrijving</label>
+                <textarea name="meta_description" class="form-control" id="meta_description"></textarea>
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_title">OG titel</label>
+                <input type="text" name="og_title" class="form-control" id="og_title">
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_description">OG omschrijving</label>
+                <textarea name="og_description" class="form-control" id="og_description"></textarea>
+              </div>
+              <div class="form-group mt-2">
+                <label for="og_image">OG afbeelding URL</label>
+                <input type="text" name="og_image" class="form-control" id="og_image">
+              </div>
             </div>
           </div>
-            
-            
         </div>
         <div class="modal-footer">
           <button class="btn btn-danger" data-bs-target="#modal" data-bs-toggle="modal" data-bs-dismiss="modal" >Annuleren</button>

--- a/admin/modules/products/forms/edit.php
+++ b/admin/modules/products/forms/edit.php
@@ -1,67 +1,98 @@
-
 <input type="hidden" name="group_id" value="<?php echo $group_id; ?>">
 <input type="hidden" id="hash" name="hash" value="">
 <div class="row mt-4">
   <div class="col-md-12">
     <div class="card shadow">
       <div class="card-body">
-        <div class="row">
-          <div class="mb-3">
-            <label for="title" class="form-label">Titel</label>
-            <?php echo input("text", 'title', $title, "title".$id, 'class="form-control autosave" data-field="title" data-set="'.$hash.'"'); ?> 
-          </div>
-          <div class="mb-3">
-            <label for="productCode" class="form-label">Productcode</label>
-            <?php echo input("text", 'productCode', $productCode, "productCode".$id, 'class="form-control autosave" data-field="productCode" data-set="'.$hash.'"'); ?>
-          </div>
-          <div class="mb-3">
-            <label for="category" class="form-label">Categorie</label>
-            <?php echo input("text", 'category', $category, "category".$id, 'class="form-control autosave" data-field="category" data-set="'.$hash.'"'); ?> 
-          </div>
-          <div class="mb-3">
-            <div class="form-group mt-2">
-              <label for="description">Omschrijving</label>
-              <?php
-              $extra = 'class="form-control autosave summernote" data-field="description" data-set="' . $hash . '"';
-              echo textarea( 'description', $description, $extra );
-              ?>
-            </div>
-          </div>
-        </div> <!-- /row -->
+        <ul class="nav nav-tabs" id="productTab" role="tablist">
+          <li class="nav-item" role="presentation">
+            <button class="nav-link active" id="general-tab" data-bs-toggle="tab" data-bs-target="#general" type="button" role="tab">Algemeen</button>
+          </li>
+          <li class="nav-item" role="presentation">
+            <button class="nav-link" id="seo-tab" data-bs-toggle="tab" data-bs-target="#seo" type="button" role="tab">SEO</button>
+          </li>
+        </ul>
+        <div class="tab-content pt-3" id="productTabContent">
+          <div class="tab-pane fade show active" id="general" role="tabpanel" aria-labelledby="general-tab">
+            <div class="row">
+              <div class="mb-3">
+                <label for="title" class="form-label">Titel</label>
+                <?php echo input("text", 'title', $title, "title".$id, 'class="form-control autosave" data-field="title" data-set="'.$hash.'"'); ?>
+              </div>
+              <div class="mb-3">
+                <label for="productCode" class="form-label">Productcode</label>
+                <?php echo input("text", 'productCode', $productCode, "productCode".$id, 'class="form-control autosave" data-field="productCode" data-set="'.$hash.'"'); ?>
+              </div>
+              <div class="mb-3">
+                <label for="category" class="form-label">Categorie</label>
+                <?php echo input("text", 'category', $category, "category".$id, 'class="form-control autosave" data-field="category" data-set="'.$hash.'"'); ?>
+              </div>
+              <div class="mb-3">
+                <div class="form-group mt-2">
+                  <label for="description">Omschrijving</label>
+                  <?php
+                  $extra = 'class="form-control autosave summernote" data-field="description" data-set="' . $hash . '"';
+                  echo textarea( 'description', $description, $extra );
+                  ?>
+                </div>
+              </div>
+            </div> <!-- /row -->
 
             <div class="container mt-2">
               <div id="cat_image" class="row">
                 <?php require_once("../admin/modules/products/bin/cat_image.php"); ?>
               </div>
-                
-                <div class="row mb-3">
-            <label for="image" class="mt-2">Afbeelding</label>
-            <div class="card card-body text-center mt-2"> <a class="btn btn-primary mt-4" id="single_cat_upload" data-set="<?php echo $hash; ?>">Selecteer een afbeelding</a> </div>
-          </div>
-                
-            </div>
-          
-          <div class="row">
-        <div class="mb-3 col-4">
-          <label for="price" class="form-label">Prijs</label>
-            
-          <?php echo input("text", 'price', $price, "price".$id, 'class="form-control autosave" data-field="price" data-set="'.$hash.'"'); ?> </div>
-        <div class="mb-3 col-4">
-          <label for="btw" class="form-label">BTW</label>
-            <div class="input-group">
-          <?php echo input("text", 'btw', $btw, "btw".$id, 'class="form-control autosave" data-field="btw" data-set="'.$hash.'"'); ?> 
-                  <div class="input-group-append">
-        <span class="input-group-text">%</span>
-      </div>
-      </div>
+
+              <div class="row mb-3">
+                <label for="image" class="mt-2">Afbeelding</label>
+                <div class="card card-body text-center mt-2">
+                  <a class="btn btn-primary mt-4" id="single_cat_upload" data-set="<?php echo $hash; ?>">Selecteer een afbeelding</a>
+                </div>
               </div>
-        <div class="mb-3 col-4">
-          <label for="stock" class="form-label" col-4>Voorraad</label>
-          <?php echo input("text", 'stock', $stock, "stock".$id, 'class="form-control autosave" data-field="stock" data-set="'.$hash.'"'); ?> </div>
-          
+            </div>
+
+            <div class="row">
+              <div class="mb-3 col-4">
+                <label for="price" class="form-label">Prijs</label>
+                <?php echo input("text", 'price', $price, "price".$id, 'class="form-control autosave" data-field="price" data-set="'.$hash.'"'); ?>
+              </div>
+              <div class="mb-3 col-4">
+                <label for="btw" class="form-label">BTW</label>
+                <div class="input-group">
+                  <?php echo input("text", 'btw', $btw, "btw".$id, 'class="form-control autosave" data-field="btw" data-set="'.$hash.'"'); ?>
+                  <div class="input-group-append"><span class="input-group-text">%</span></div>
+                </div>
+              </div>
+              <div class="mb-3 col-4">
+                <label for="stock" class="form-label" col-4>Voorraad</label>
+                <?php echo input("text", 'stock', $stock, "stock".$id, 'class="form-control autosave" data-field="stock" data-set="'.$hash.'"'); ?>
+              </div>
+            </div>
+          </div>
+          <div class="tab-pane fade" id="seo" role="tabpanel" aria-labelledby="seo-tab">
+            <div class="mb-3">
+              <label for="meta_title" class="form-label">Meta titel</label>
+              <?php echo input("text", 'meta_title', $meta_title, "meta_title".$id, 'class="form-control autosave" data-field="meta_title" data-set="'.$hash.'"'); ?>
+            </div>
+            <div class="mb-3">
+              <label for="meta_description" class="form-label">Meta omschrijving</label>
+              <?php echo textarea('meta_description', $meta_description, 'class="form-control autosave" data-field="meta_description" data-set="'.$hash.'"'); ?>
+            </div>
+            <div class="mb-3">
+              <label for="og_title" class="form-label">OG titel</label>
+              <?php echo input("text", 'og_title', $og_title, "og_title".$id, 'class="form-control autosave" data-field="og_title" data-set="'.$hash.'"'); ?>
+            </div>
+            <div class="mb-3">
+              <label for="og_description" class="form-label">OG omschrijving</label>
+              <?php echo textarea('og_description', $og_description, 'class="form-control autosave" data-field="og_description" data-set="'.$hash.'"'); ?>
+            </div>
+            <div class="mb-3">
+              <label for="og_image" class="form-label">OG afbeelding URL</label>
+              <?php echo input("text", 'og_image', $og_image, "og_image".$id, 'class="form-control autosave" data-field="og_image" data-set="'.$hash.'"'); ?>
+            </div>
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
 </div>

--- a/head.php
+++ b/head.php
@@ -1,1 +1,12 @@
-<!--- code for head goes here --->
+<?php
+$meta_title = $meta_title ?? ($title ?? '');
+$meta_description = $meta_description ?? '';
+$meta_image = $meta_image ?? '';
+?>
+<title><?= htmlspecialchars($meta_title, ENT_QUOTES, 'UTF-8'); ?></title>
+<meta name="description" content="<?= htmlspecialchars($meta_description, ENT_QUOTES, 'UTF-8'); ?>">
+<meta property="og:title" content="<?= htmlspecialchars($meta_title, ENT_QUOTES, 'UTF-8'); ?>">
+<meta property="og:description" content="<?= htmlspecialchars($meta_description, ENT_QUOTES, 'UTF-8'); ?>">
+<?php if (!empty($meta_image)): ?>
+<meta property="og:image" content="<?= htmlspecialchars($meta_image, ENT_QUOTES, 'UTF-8'); ?>">
+<?php endif; ?>

--- a/index.php
+++ b/index.php
@@ -3,9 +3,8 @@
 <html lang="nl"><head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-
-  <title><?php echo $title; ?></title>
-  <meta content="<?php echo $meta_description; ?>" name="description">
+  <?php $meta_title = $title; ?>
+  <?php require('head.php'); ?>
   <meta content="<?php echo $meta_keywords; ?>" name="keywords">
 
   <!-- Favicons -- >

--- a/inner.php
+++ b/inner.php
@@ -54,9 +54,11 @@ $title = $article['title'];
 <head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-
-  <title><?php echo $title." | ".$info['web_naam']; ?></title>
-  <meta content="<?php echo $info['description']; ?>" name="description">
+  <?php
+  $meta_title = $title . " | " . $info['web_naam'];
+  $meta_description = $info['description'];
+  ?>
+  <?php require("head.php"); ?>
   <meta content="<?php echo $info['keywords']; ?>" name="keywords">
 
   <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>
@@ -97,7 +99,6 @@ $( document ).ready( function () {
 	
 });
 </script>
-<?php require("head.php"); ?>
 </head>
 
 <body>

--- a/productpage.php
+++ b/productpage.php
@@ -3,9 +3,8 @@
 <html lang="nl"><head>
   <meta charset="utf-8">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
-
-  <title><?php echo $title; ?> | producten</title>
-  <meta content="<?php echo $meta_description; ?>" name="description">
+  <?php $meta_title = $title . ' | producten'; ?>
+  <?php require('head.php'); ?>
   <meta content="<?php echo $meta_keywords; ?>" name="keywords">
 
   <script src="https://code.jquery.com/jquery-3.6.0.min.js" integrity="sha256-/xUj+3OJU5yExlq6GSYGSHk7tPXikynS7ogEvDej/m4=" crossorigin="anonymous"></script>


### PR DESCRIPTION
## Summary
- add PHP script to export active content and products to sitemap.xml
- centralize meta and Open Graph tags in head.php and use across pages
- introduce SEO tabs in admin forms for products and content

## Testing
- `php -l sitemap.php head.php index.php productpage.php inner.php admin/modules/products/edit.php admin/modules/products/forms/edit.php admin/modules/products/forms/add.php admin/modules/content/edit.php admin/modules/content/forms/edit.php admin/modules/content/forms/add.php`
- `php sitemap.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_689db5ac4478832a8ab7373529f1372c