### PR TITLE
Add SEO helper tools

### DIFF
--- a/admin/modules/siteconfig/forms/seo.php
+++ b/admin/modules/siteconfig/forms/seo.php
@@ -53,6 +53,37 @@
       </ul>
     </div>
   </div>
+  <div class="row mt-4">
+    <div class="col-md-12">
+      <h4>Kleine tools ter ondersteuning van vindbaarheid</h4>
+
+      <div class="mt-3">
+        <h5>SEO Snippet Preview</h5>
+        <input type="text" id="snippet-title" class="form-control mb-2" placeholder="Paginatitel">
+        <input type="text" id="snippet-description" class="form-control mb-2" placeholder="Meta beschrijving">
+        <div class="border p-2">
+          <div id="preview-title" class="fw-bold">Voorbeeld titel</div>
+          <div id="preview-url" class="text-success">www.jouwsite.nl</div>
+          <div id="preview-description">Voorbeeld beschrijving</div>
+        </div>
+      </div>
+
+      <div class="mt-4">
+        <h5>Zoekwoordanalyse-widget</h5>
+        <textarea id="keyword-content" class="form-control mb-2" rows="3" placeholder="Plak hier de pagina-inhoud"></textarea>
+        <button class="btn btn-primary" id="analyze-keywords" type="button">Analyseer</button>
+        <ul id="keyword-results" class="mt-2"></ul>
+      </div>
+
+      <div class="mt-4">
+        <h5>Broken Link Checker</h5>
+        <textarea id="link-checker-urls" class="form-control mb-2" rows="3" placeholder="Eén URL per regel"></textarea>
+        <button class="btn btn-primary" id="check-links" type="button">Controleer</button>
+        <ul id="link-results" class="mt-2"></ul>
+      </div>
+
+    </div>
+  </div>
   </div>
 </div>
 

--- a/admin/modules/siteconfig/index.php
+++ b/admin/modules/siteconfig/index.php
@@ -44,3 +44,4 @@ echo "<small>Site ID: " . $sid . "</small>";
 </div>
 
 <script src="/admin/modules/siteconfig/js/js.js"></script>
+<script src="/admin/modules/siteconfig/js/seo_tools.js"></script>

--- a/admin/modules/siteconfig/js/seo_tools.js
+++ b/admin/modules/siteconfig/js/seo_tools.js
@@ -1,0 +1,36 @@
+$(document).ready(function () {
+  function updateSnippet() {
+    var title = $("#snippet-title").val() || "Voorbeeld titel";
+    var description = $("#snippet-description").val() || "Voorbeeld beschrijving";
+    $("#preview-title").text(title);
+    $("#preview-description").text(description);
+  }
+  $("#snippet-title, #snippet-description").on("input", updateSnippet);
+
+  $("#analyze-keywords").on("click", function () {
+    var text = $("#keyword-content").val().toLowerCase();
+    var words = text.match(/\b(\w+)\b/g) || [];
+    var counts = {};
+    words.forEach(function (w) {
+      if (w.length <= 3) return;
+      counts[w] = (counts[w] || 0) + 1;
+    });
+    var sorted = Object.entries(counts).sort(function (a, b) { return b[1] - a[1]; }).slice(0, 10);
+    var list = $("#keyword-results").empty();
+    sorted.forEach(function (pair) {
+      list.append($("<li>").text(pair[0] + " (" + pair[1] + ")"));
+    });
+  });
+
+  $("#check-links").on("click", function () {
+    var urls = $("#link-checker-urls").val().split(/\n+/).filter(Boolean);
+    var list = $("#link-results").empty();
+    urls.forEach(function (url) {
+      $.post("/admin/modules/siteconfig/tools/broken_link_checker.php", { url: url }, function (data) {
+        list.append($("<li>").text(url + ": " + data.status));
+      }, "json").fail(function () {
+        list.append($("<li>").text(url + ": fout bij controleren"));
+      });
+    });
+  });
+});

--- a/admin/modules/siteconfig/tools/broken_link_checker.php
+++ b/admin/modules/siteconfig/tools/broken_link_checker.php
@@ -1,0 +1,23 @@
+<?php
+header('Content-Type: application/json');
+$url = $_POST['url'] ?? '';
+$status = '';
+if ($url && filter_var($url, FILTER_VALIDATE_URL)) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_NOBODY, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 10);
+    curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
+    curl_exec($ch);
+    if (curl_errno($ch)) {
+        $status = 'error';
+    } else {
+        $status = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    }
+    curl_close($ch);
+}
+if ($status === '') {
+    $status = 'invalid';
+}
+echo json_encode(['status' => $status]);


### PR DESCRIPTION
## Summary
- add SEO snippet preview, keyword analyzer, and broken link checker under site config SEO tab
- include new JS handlers and link checking endpoint

## Testing
- `php -l admin/modules/siteconfig/forms/seo.php`
- `php -l admin/modules/siteconfig/index.php`
- `php -l admin/modules/siteconfig/tools/broken_link_checker.php`
- `node --check admin/modules/siteconfig/js/seo_tools.js`


------
https://chatgpt.com/codex/tasks/task_e_689e49537168832a98f2ec44e295b8bc