### PR TITLE
Fix unbalanced div in colors form

### DIFF
--- a/admin/modules/siteconfig/forms/colors.php
+++ b/admin/modules/siteconfig/forms/colors.php
@@ -171,6 +171,7 @@
         <?php echo selectboxFont('Slogan Font Familie', 'sloganFontFamily', $data['sloganFontFamily'] ?? '', 'class="form-select autosave_config_site" data-field="sloganFontFamily" data-set="'.$data['id'].'"'); ?>
     </div>
 </div>
+</div>
 <hr>
 <div class="container mt-3">
     <h3>Navigation Menu Instellingen</h3>


### PR DESCRIPTION
## Summary
- close the missing div in the Header Instellingen section of the colors form

## Testing
- `php -l admin/modules/siteconfig/forms/colors.php`
- `grep -o '<div' -n admin/modules/siteconfig/forms/colors.php | wc -l`
- `grep -o '</div>' -n admin/modules/siteconfig/forms/colors.php | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_689e60b14b78832a8ad707d373907fab