### PR TITLE
Add modules dashboard and fix logout redirect

### DIFF
--- a/logout.php
+++ b/logout.php
@@ -7,7 +7,7 @@ $_SESSION = array();
 // Vernietig de sessie
 session_destroy();
 
-// Stuur de gebruiker door naar de inlogpagina
-header("Location: login.php");
+// Stuur de gebruiker door naar de inlogpagina module
+header("Location: index.php?module=login");
 exit;
 ?>

--- a/modules/modules/controller.php
+++ b/modules/modules/controller.php
@@ -1,0 +1,18 @@
+<?php
+$config = Core::config();
+$title = 'Modules';
+$meta_description = $config['site_title'] ?? '';
+$meta_keywords = '';
+$site_location = $config['site_location'] ?? '/';
+$theme = $config['theme'] ?? '';
+
+$modulesDir = dirname(__DIR__);
+$availableModules = array_filter(scandir($modulesDir), function($item) use ($modulesDir) {
+    return $item[0] !== '.'
+        && is_dir($modulesDir . '/' . $item)
+        && file_exists($modulesDir . '/' . $item . '/controller.php')
+        && !in_array($item, ['home', 'modules']);
+});
+
+require __DIR__ . '/view.php';
+?>

--- a/modules/modules/view.php
+++ b/modules/modules/view.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="nl"><head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1.0" name="viewport">
+  <title><?php echo $title; ?></title>
+  <meta content="<?php echo $meta_description; ?>" name="description">
+  <meta content="<?php echo $meta_keywords; ?>" name="keywords">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/boxicons/css/boxicons.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/swiper/swiper-bundle.min.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?><?php echo $theme; ?>/assets/css/style.css" rel="stylesheet">
+  <link href="<?php echo $site_location; ?>assets/css/transitions-optimized.css" rel="stylesheet">
+</head>
+<body>
+<div id="display" class="alert-fixed"></div>
+<?php require_once($theme."/sections/header.php"); ?>
+<section class="mt-5">
+  <div class="container mt-5">
+    <h3>Modules</h3>
+    <div class="row row-cols-1 row-cols-md-3 g-4">
+      <?php foreach ($availableModules as $mod): ?>
+      <div class="col">
+        <div class="card h-100 text-center">
+          <div class="card-body">
+            <h5 class="card-title"><?php echo ucfirst($mod); ?></h5>
+          </div>
+        </div>
+      </div>
+      <?php endforeach; ?>
+      <?php for ($i = 0; $i < 5; $i++): ?>
+      <div class="col">
+        <div class="card h-100 text-center placeholder-card">
+          <div class="card-body">
+            <h5 class="card-title">Placeholder</h5>
+          </div>
+        </div>
+      </div>
+      <?php endfor; ?>
+    </div>
+  </div>
+</section>
+<?php require_once($theme."/sections/footer.php"); ?>
+<script src="<?php echo $site_location; ?><?php echo $theme; ?>/assets/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+<script src="<?php echo $site_location; ?><?php echo $theme; ?>/assets/js/main.js"></script>
+<script src="<?php echo $site_location; ?>assets/js/transitions-optimizer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `modules` module that lists installed modules and shows five placeholder cards
- Redirect logout to the login module to avoid 404 after signing out

## Testing
- `php -l modules/modules/controller.php`
- `php -l modules/modules/view.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb615e98b0832a90957d0fca655386