### PR TITLE
Ensure navigation data and PDO initialization

### DIFF
--- a/modules/home/controller.php
+++ b/modules/home/controller.php
@@ -1,9 +1,37 @@
 <?php
+require_once __DIR__ . '/../../src/site.class.php';
+
 $config = Core::config();
 $title = $config['site_title'] ?? 'Home';
 $meta_description = $config['site_title'] ?? '';
 $meta_keywords = '';
 $site_location = $config['site_location'] ?? '/';
 $theme = $config['theme'] ?? '';
+
+// Session identifier
+$sessid = session_id();
+
+// Set up site data
+$pdo = Core::db()->getPdo();
+$site = new site($pdo);
+
+$domain = str_replace('www.', '', $_SERVER['HTTP_HOST']);
+$configRow = $site->getConfig($domain);
+$web_naam = $configRow['web_naam'] ?? '';
+$groupData = $site->getGroupId($web_naam);
+$group_id = $groupData['group_id'] ?? 0;
+
+$menu = $site->getActiveMenuItems($group_id);
+if (!is_array($menu)) {
+    $menu = [];
+}
+
+$sections = $site->getActiveContent($group_id);
+if (!is_array($sections)) {
+    $sections = [];
+}
+
+$info = $site->getWebsiteInfo($group_id);
+
 require __DIR__ . '/view.php';
 ?>

--- a/src/database.class.php
+++ b/src/database.class.php
@@ -33,8 +33,8 @@ class database {
     {
         $this->pdo = $pdo;
     }
-  
-	public function runQuery($sql, $parameters = []) {
+
+        public function runQuery($sql, $parameters = []) {
     
         $stmt = $this->pdo->prepare($sql);
     
@@ -54,8 +54,16 @@ class database {
 		} else {
 		  return false;
 		}
-	}*/
-    
+        }*/
+
+    /**
+     * Provide access to the underlying PDO instance
+     */
+    public function getPdo(): PDO
+    {
+        return $this->pdo;
+    }
+
   public function countQuery($sql, $parameters = []) {
     $stmt = $this->pdo->prepare($sql);
     $stmt->execute($parameters);

--- a/themes/onepage/sections/navbar.php
+++ b/themes/onepage/sections/navbar.php
@@ -1,4 +1,4 @@
-<?php $loc_website = "https://www.webstoremanager.nl"; ?>
+<?php $loc_website = $site_location ?? ''; ?>
 
 <nav id="navbar" class="navbar">
   <ul>
@@ -6,18 +6,18 @@
 <?php
 $i = 0;
 $nav = '';
-foreach($menu as $row => $value) {
-	
-	$class = ($i == 0) ? 'nav-link scrollto active' : 'nav-link scrollto';
-
-	$nav .= '<li><a class="'.$class.'" href="'.$loc_website."/".$value['location'].'">'.$value['title'].'</a></li>';
-	$nav .= "\n";
-	$i++;
+if (!empty($menu) && is_array($menu)) {
+    foreach ($menu as $row => $value) {
+        $class = ($i == 0) ? 'nav-link scrollto active' : 'nav-link scrollto';
+        $nav .= '<li><a class="' . $class . '" href="' . $loc_website . $value['location'] . '">' . $value['title'] . '</a></li>';
+        $nav .= "\n";
+        $i++;
+    }
 }
 
 echo $nav;
 ?>
   </ul>
-  <i class="bi bi-list mobile-nav-toggle"></i> 
+  <i class="bi bi-list mobile-nav-toggle"></i>
 </nav>
 <!-- .navbar -->


### PR DESCRIPTION
## Summary
- Expose PDO instance from database wrapper for reuse
- Initialize session, PDO, site information and menu in home controller
- Guard navbar rendering when menu is empty

## Testing
- `php -l src/database.class.php`
- `php -l modules/home/controller.php`
- `php -l themes/onepage/sections/navbar.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb65522dac832ab1d430972ccffbe5