### PR TITLE
Use absolute paths for test URL filtering script

### DIFF
--- a/admin/bin/test_url_filtering.php
+++ b/admin/bin/test_url_filtering.php
@@ -1,7 +1,7 @@
 <?php
 // Test script for URL filtering
-require_once("../../system/database.php");
-require_once("../src/analytics.class.php");
+require_once __DIR__ . '/../../system/database.php';
+require_once __DIR__ . '/../src/analytics.class.php';
 
 try {
     $analytics = new Analytics($pdo);


### PR DESCRIPTION
## Summary
- Use `__DIR__` to reference `system/database.php` and `src/analytics.class.php`

## Testing
- `php -l admin/bin/test_url_filtering.php`
- `php admin/bin/test_url_filtering.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6895c96a5224832a99413093b1c76a67