### PR TITLE
Add dynamic URL helper for flexible deployment

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -4,7 +4,7 @@ return [
     'db_name' => 'ajmweb_wm',
     'db_user' => 'ajmweb_wm',
     'db_password' => 'ASDFGH01',
-    'site_location' => 'http://localhost/',
+    'site_location' => Core::url(),
     'theme' => 'themes/onepage'
 ];
 ?>

--- a/src/core.php
+++ b/src/core.php
@@ -30,5 +30,18 @@ class Core
         }
         return self::$config[$key] ?? null;
     }
+
+    public static function url(string $path = ''): string
+    {
+        $isSecure = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || (isset($_SERVER['SERVER_PORT']) && $_SERVER['SERVER_PORT'] == 443);
+        $scheme = $isSecure ? 'https://' : 'http://';
+        $host = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $scriptName = $_SERVER['SCRIPT_NAME'] ?? '';
+        $basePath = rtrim(str_replace('\\', '/', dirname($scriptName)), '/');
+        $base = $scheme . $host . ($basePath ? $basePath . '/' : '/');
+
+        return $base . ltrim($path, '/');
+    }
 }
 ?>


### PR DESCRIPTION
## Summary
- add `Core::url` helper to compute base URLs from current request
- configure `site_location` to use dynamic base URL instead of localhost

## Testing
- `php -l src/core.php`
- `php -l config/app.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe345021c832ab4c5d8727cb7b7d6