### PR TITLE
Avoid undefined index warnings for content meta fields

### DIFF
--- a/admin/modules/content/edit.php
+++ b/admin/modules/content/edit.php
@@ -38,8 +38,9 @@ if ($result && is_array($result)) {
 		$keywords 	= $row['keywords'];
 		$sortnum 	= $row['sortnum'];
 		$status 	= $row['status'];
-		$meta_title 	= $row['meta_title'];
-		$meta_description = $row['meta_description'];
+		// Provide fallbacks for optional SEO fields to avoid undefined index warnings
+		$meta_title       = $row['meta_title'] ?? '';
+		$meta_description = $row['meta_description'] ?? '';
 
 		$selectbox = selectbox("Kies menu item", 'location', $location, array_combine($MenuLocations, $MenuNames), 'class="form-select autosave" data-field="location" data-set="'.$hash.'"');
     }


### PR DESCRIPTION
## Summary
- prevent warnings when `meta_title` or `meta_description` are missing by providing default empty strings

## Testing
- `php -l admin/modules/content/edit.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbee3090b8832a9e2f9c9564f15a2d