### PR TITLE
Handle missing photoslider settings table

### DIFF
--- a/admin/modules/photoslider/install_missing_table.php
+++ b/admin/modules/photoslider/install_missing_table.php
@@ -2,8 +2,11 @@
 /**
  * Install Missing Table for Photoslider Module
  * 
- * This script creates the missing group_photoslider_names table
- * that is required for the photoslider module to function properly.
+ * This script creates the missing database tables for the photoslider module.
+ *
+ * Tables created:
+ * - group_photoslider_names
+ * - group_photoslider_settings
  */
 
 // Include database connection
@@ -11,7 +14,7 @@ $path = $_SERVER['DOCUMENT_ROOT'];
 require_once($path . "/system/database.php");
 
 try {
-    // Create the missing table
+    // Create the missing tables
     $sql = "CREATE TABLE IF NOT EXISTS `group_photoslider_names` (
         `id` int(11) NOT NULL AUTO_INCREMENT,
         `name` varchar(255) NOT NULL,
@@ -22,11 +25,29 @@ try {
     ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
 
     $pdo->exec($sql);
+
+    // Create settings table if it doesn't exist
+    $sql = "CREATE TABLE IF NOT EXISTS `group_photoslider_settings` (
+        `id` int(11) NOT NULL AUTO_INCREMENT,
+        `group_id` int(11) NOT NULL,
+        `hash` varchar(255) NOT NULL,
+        `height` int(11) DEFAULT 480,
+        `speed` int(11) DEFAULT 4000,
+        `buttons` varchar(1) DEFAULT 'y',
+        `indicators` varchar(1) DEFAULT 'y',
+        `folder` varchar(255) DEFAULT NULL,
+        `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        `updated_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+        PRIMARY KEY (`id`),
+        KEY `group_id` (`group_id`)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci";
+
+    $pdo->exec($sql);
     
     // Insert a default slider if none exists
     $checkSql = "SELECT COUNT(*) FROM group_photoslider_names";
     $count = $pdo->query($checkSql)->fetchColumn();
-    
+
     if ($count == 0) {
         $insertSql = "INSERT INTO group_photoslider_names (name) VALUES ('Default Slider')";
         $pdo->exec($insertSql);
@@ -34,7 +55,21 @@ try {
     } else {
         echo "✅ Created group_photoslider_names table (already had data).<br>";
     }
-    
+
+    // Insert default settings if none exist
+    $checkSql = "SELECT COUNT(*) FROM group_photoslider_settings";
+    $count = $pdo->query($checkSql)->fetchColumn();
+
+    if ($count == 0) {
+        $hash = bin2hex(random_bytes(16));
+        $insertSql = "INSERT INTO group_photoslider_settings (group_id, hash, height, speed, buttons, indicators, folder) VALUES (1, :hash, 480, 4000, 'y', 'y', '')";
+        $stmt = $pdo->prepare($insertSql);
+        $stmt->execute(['hash' => $hash]);
+        echo "✅ Created group_photoslider_settings table and added default settings.<br>";
+    } else {
+        echo "✅ Created group_photoslider_settings table (already had data).<br>";
+    }
+
     echo "✅ Photoslider module database setup complete!<br>";
     echo "<br><strong>You can now safely use the photoslider module.</strong><br>";
     echo "<br><a href='/admin/?module=photoslider' class='btn btn-primary'>Go to Photoslider Module</a>";

--- a/admin/modules/photoslider/src/photoslider.class.php
+++ b/admin/modules/photoslider/src/photoslider.class.php
@@ -32,14 +32,30 @@ class photoslider {
     }
     
     function getPhotosliderSettings($group_id) {
-        $sql = "SELECT * FROM group_photoslider_settings WHERE group_id = :group_id";
-        $stmt = $this->pdo->prepare($sql);
-        $stmt->execute(['group_id' => $group_id]);
-        $row = $stmt->fetch();
-        if(!empty($row)) {
-            return($row);
-        } else {
-            return false;
+        try {
+            $sql = "SELECT * FROM group_photoslider_settings WHERE group_id = :group_id";
+            $stmt = $this->pdo->prepare($sql);
+            $stmt->execute(['group_id' => $group_id]);
+            $row = $stmt->fetch();
+            if(!empty($row)) {
+                return($row);
+            } else {
+                return false;
+            }
+        } catch (PDOException $e) {
+            // If the settings table doesn't exist yet, return default settings
+            if ($e->getCode() == '42S02') {
+                return [
+                    'group_id'   => $group_id,
+                    'hash'       => '',
+                    'height'     => 480,
+                    'speed'      => 4000,
+                    'buttons'    => 'y',
+                    'indicators' => 'y',
+                    'folder'     => ''
+                ];
+            }
+            throw $e;
         }
     }
 


### PR DESCRIPTION
## Summary
- handle missing photoslider settings table by returning defaults when absent
- expand photoslider installer to create settings table with default record

## Testing
- `php -l admin/modules/photoslider/src/photoslider.class.php`
- `php -l admin/modules/photoslider/install_missing_table.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbed2ce988832a8bf901b483dd237c